### PR TITLE
Add error handling for incoming write messages that are not allowed

### DIFF
--- a/model/alarm_additions.go
+++ b/model/alarm_additions.go
@@ -4,11 +4,17 @@ package model
 
 var _ Updater = (*AlarmListDataType)(nil)
 
-func (r *AlarmListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *AlarmListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []AlarmDataType
 	if newList != nil {
 		newData = newList.(*AlarmListDataType).AlarmListData
 	}
 
-	r.AlarmListData = UpdateList(remoteWrite, r.AlarmListData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.AlarmListData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.AlarmListData = data
+	}
+
+	return success
 }

--- a/model/alarm_additions_test.go
+++ b/model/alarm_additions_test.go
@@ -31,7 +31,8 @@ func TestAlarmListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.AlarmListData
 	// check the non changing items

--- a/model/bill_additions.go
+++ b/model/bill_additions.go
@@ -4,37 +4,55 @@ package model
 
 var _ Updater = (*BillListDataType)(nil)
 
-func (r *BillListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *BillListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []BillDataType
 	if newList != nil {
 		newData = newList.(*BillListDataType).BillData
 	}
 
-	r.BillData = UpdateList(remoteWrite, r.BillData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.BillData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.BillData = data
+	}
+
+	return success
 }
 
 // BillConstraintsListDataType
 
 var _ Updater = (*BillConstraintsListDataType)(nil)
 
-func (r *BillConstraintsListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *BillConstraintsListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []BillConstraintsDataType
 	if newList != nil {
 		newData = newList.(*BillConstraintsListDataType).BillConstraintsData
 	}
 
-	r.BillConstraintsData = UpdateList(remoteWrite, r.BillConstraintsData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.BillConstraintsData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.BillConstraintsData = data
+	}
+
+	return success
 }
 
 // BillDescriptionListDataType
 
 var _ Updater = (*BillDescriptionListDataType)(nil)
 
-func (r *BillDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *BillDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []BillDescriptionDataType
 	if newList != nil {
 		newData = newList.(*BillDescriptionListDataType).BillDescriptionData
 	}
 
-	r.BillDescriptionData = UpdateList(remoteWrite, r.BillDescriptionData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.BillDescriptionData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.BillDescriptionData = data
+	}
+
+	return success
 }

--- a/model/bill_additions_test.go
+++ b/model/bill_additions_test.go
@@ -31,7 +31,8 @@ func TestBillListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.BillData
 	// check the non changing items
@@ -69,7 +70,8 @@ func TestBillConstraintsListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.BillConstraintsData
 	// check the non changing items
@@ -107,7 +109,8 @@ func TestBillDescriptionListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.BillDescriptionData
 	// check the non changing items

--- a/model/bindingmanagement_additions.go
+++ b/model/bindingmanagement_additions.go
@@ -4,11 +4,17 @@ package model
 
 var _ Updater = (*BindingManagementEntryListDataType)(nil)
 
-func (r *BindingManagementEntryListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *BindingManagementEntryListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []BindingManagementEntryDataType
 	if newList != nil {
 		newData = newList.(*BindingManagementEntryListDataType).BindingManagementEntryData
 	}
 
-	r.BindingManagementEntryData = UpdateList(remoteWrite, r.BindingManagementEntryData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.BindingManagementEntryData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.BindingManagementEntryData = data
+	}
+
+	return success
 }

--- a/model/bindingmanagement_additions_test.go
+++ b/model/bindingmanagement_additions_test.go
@@ -31,7 +31,8 @@ func TestBindingManagementEntryListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.BindingManagementEntryData
 	// check the non changing items

--- a/model/collection_operations_test.go
+++ b/model/collection_operations_test.go
@@ -35,7 +35,8 @@ func TestUnion_NewData(t *testing.T) {
 	}
 
 	// Act
-	result := Merge(false, existingData, newData)
+	result, boolV := Merge(false, existingData, newData)
+	assert.True(t, boolV)
 
 	if assert.Equal(t, 2, len(result)) {
 		assert.Equal(t, 1, int(*result[0].Id))
@@ -60,7 +61,8 @@ func TestUnion_NewAndUpdateData(t *testing.T) {
 	}
 
 	// Act
-	result := Merge(false, existingData, newData)
+	result, boolV := Merge(false, existingData, newData)
+	assert.True(t, boolV)
 
 	if assert.Equal(t, 4, len(result)) {
 		assert.Equal(t, 0, int(*result[0].Id))
@@ -94,7 +96,8 @@ func TestUnion_NewAndUpdateDataRemoteWrite(t *testing.T) {
 	}
 
 	// Act
-	result := Merge(true, existingData, newData)
+	result, boolV := Merge(true, existingData, newData)
+	assert.False(t, boolV)
 
 	if assert.Equal(t, 4, len(result)) {
 		assert.Equal(t, 0, int(*result[0].Id))
@@ -128,7 +131,8 @@ func TestUnion_InvalidData(t *testing.T) {
 	}
 
 	// Act
-	result := Merge(true, existingData, newData)
+	result, boolV := Merge(true, existingData, newData)
+	assert.False(t, boolV)
 
 	if assert.Equal(t, 4, len(result)) {
 		assert.Equal(t, 0, int(*result[0].Id))

--- a/model/custom_test.go
+++ b/model/custom_test.go
@@ -16,11 +16,6 @@ type ErrorTypeSuite struct {
 	suite.Suite
 }
 
-func (s *ErrorTypeSuite) SetupSuite()   {}
-func (s *ErrorTypeSuite) TearDownTest() {}
-
-func (s *ErrorTypeSuite) BeforeTest(suiteName, testName string) {}
-
 func (s *ErrorTypeSuite) Test_NewErrorType() {
 	result := NewErrorType(ErrorNumberTypeNoError, "")
 	assert.NotNil(s.T(), result)

--- a/model/deviceconfiguration_additions.go
+++ b/model/deviceconfiguration_additions.go
@@ -4,37 +4,55 @@ package model
 
 var _ Updater = (*DeviceConfigurationKeyValueListDataType)(nil)
 
-func (r *DeviceConfigurationKeyValueListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *DeviceConfigurationKeyValueListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []DeviceConfigurationKeyValueDataType
 	if newList != nil {
 		newData = newList.(*DeviceConfigurationKeyValueListDataType).DeviceConfigurationKeyValueData
 	}
 
-	r.DeviceConfigurationKeyValueData = UpdateList(remoteWrite, r.DeviceConfigurationKeyValueData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.DeviceConfigurationKeyValueData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.DeviceConfigurationKeyValueData = data
+	}
+
+	return success
 }
 
 // DeviceConfigurationKeyValueDescriptionListDataType
 
 var _ Updater = (*DeviceConfigurationKeyValueDescriptionListDataType)(nil)
 
-func (r *DeviceConfigurationKeyValueDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *DeviceConfigurationKeyValueDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []DeviceConfigurationKeyValueDescriptionDataType
 	if newList != nil {
 		newData = newList.(*DeviceConfigurationKeyValueDescriptionListDataType).DeviceConfigurationKeyValueDescriptionData
 	}
 
-	r.DeviceConfigurationKeyValueDescriptionData = UpdateList(remoteWrite, r.DeviceConfigurationKeyValueDescriptionData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.DeviceConfigurationKeyValueDescriptionData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.DeviceConfigurationKeyValueDescriptionData = data
+	}
+
+	return success
 }
 
 // DeviceConfigurationKeyValueConstraintsListDataType
 
 var _ Updater = (*DeviceConfigurationKeyValueConstraintsListDataType)(nil)
 
-func (r *DeviceConfigurationKeyValueConstraintsListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *DeviceConfigurationKeyValueConstraintsListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []DeviceConfigurationKeyValueConstraintsDataType
 	if newList != nil {
 		newData = newList.(*DeviceConfigurationKeyValueConstraintsListDataType).DeviceConfigurationKeyValueConstraintsData
 	}
 
-	r.DeviceConfigurationKeyValueConstraintsData = UpdateList(remoteWrite, r.DeviceConfigurationKeyValueConstraintsData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.DeviceConfigurationKeyValueConstraintsData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.DeviceConfigurationKeyValueConstraintsData = data
+	}
+
+	return success
 }

--- a/model/deviceconfiguration_additions_test.go
+++ b/model/deviceconfiguration_additions_test.go
@@ -38,18 +38,19 @@ func TestDeviceConfigurationKeyValueListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.DeviceConfigurationKeyValueData
 	// check the non changing items
 	assert.Equal(t, 2, len(data))
 	item1 := data[0]
 	assert.Equal(t, 0, int(*item1.KeyId))
-	assert.Equal(t, true, *item1.Value.Boolean)
+	assert.True(t, *item1.Value.Boolean)
 	// check properties of updated item
 	item2 := data[1]
 	assert.Equal(t, 1, int(*item2.KeyId))
-	assert.Equal(t, false, *item2.Value.Boolean)
+	assert.False(t, *item2.Value.Boolean)
 }
 
 func TestDeviceConfigurationKeyValueDescriptionListDataType_Update(t *testing.T) {
@@ -76,7 +77,8 @@ func TestDeviceConfigurationKeyValueDescriptionListDataType_Update(t *testing.T)
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.DeviceConfigurationKeyValueDescriptionData
 	// check the non changing items
@@ -120,7 +122,8 @@ func TestDeviceConfigurationKeyValueConstraintsListDataType_Update(t *testing.T)
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.DeviceConfigurationKeyValueConstraintsData
 	// check the non changing items

--- a/model/electricalconnection_additions.go
+++ b/model/electricalconnection_additions.go
@@ -4,63 +4,93 @@ package model
 
 var _ Updater = (*ElectricalConnectionStateListDataType)(nil)
 
-func (r *ElectricalConnectionStateListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *ElectricalConnectionStateListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []ElectricalConnectionStateDataType
 	if newList != nil {
 		newData = newList.(*ElectricalConnectionStateListDataType).ElectricalConnectionStateData
 	}
 
-	r.ElectricalConnectionStateData = UpdateList(remoteWrite, r.ElectricalConnectionStateData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.ElectricalConnectionStateData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.ElectricalConnectionStateData = data
+	}
+
+	return success
 }
 
 // ElectricalConnectionPermittedValueSetListDataType
 
 var _ Updater = (*ElectricalConnectionPermittedValueSetListDataType)(nil)
 
-func (r *ElectricalConnectionPermittedValueSetListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *ElectricalConnectionPermittedValueSetListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []ElectricalConnectionPermittedValueSetDataType
 	if newList != nil {
 		newData = newList.(*ElectricalConnectionPermittedValueSetListDataType).ElectricalConnectionPermittedValueSetData
 	}
 
-	r.ElectricalConnectionPermittedValueSetData = UpdateList(remoteWrite, r.ElectricalConnectionPermittedValueSetData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.ElectricalConnectionPermittedValueSetData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.ElectricalConnectionPermittedValueSetData = data
+	}
+
+	return success
 }
 
 // ElectricalConnectionDescriptionListDataType
 
 var _ Updater = (*ElectricalConnectionDescriptionListDataType)(nil)
 
-func (r *ElectricalConnectionDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *ElectricalConnectionDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []ElectricalConnectionDescriptionDataType
 	if newList != nil {
 		newData = newList.(*ElectricalConnectionDescriptionListDataType).ElectricalConnectionDescriptionData
 	}
 
-	r.ElectricalConnectionDescriptionData = UpdateList(remoteWrite, r.ElectricalConnectionDescriptionData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.ElectricalConnectionDescriptionData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.ElectricalConnectionDescriptionData = data
+	}
+
+	return success
 }
 
 // ElectricalConnectionCharacteristicListDataType
 
 var _ Updater = (*ElectricalConnectionCharacteristicListDataType)(nil)
 
-func (r *ElectricalConnectionCharacteristicListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *ElectricalConnectionCharacteristicListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []ElectricalConnectionCharacteristicDataType
 	if newList != nil {
 		newData = newList.(*ElectricalConnectionCharacteristicListDataType).ElectricalConnectionCharacteristicData
 	}
 
-	r.ElectricalConnectionCharacteristicData = UpdateList(remoteWrite, r.ElectricalConnectionCharacteristicData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.ElectricalConnectionCharacteristicData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.ElectricalConnectionCharacteristicData = data
+	}
+
+	return success
 }
 
 // ElectricalConnectionParameterDescriptionListDataType
 
 var _ Updater = (*ElectricalConnectionParameterDescriptionListDataType)(nil)
 
-func (r *ElectricalConnectionParameterDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *ElectricalConnectionParameterDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []ElectricalConnectionParameterDescriptionDataType
 	if newList != nil {
 		newData = newList.(*ElectricalConnectionParameterDescriptionListDataType).ElectricalConnectionParameterDescriptionData
 	}
 
-	r.ElectricalConnectionParameterDescriptionData = UpdateList(remoteWrite, r.ElectricalConnectionParameterDescriptionData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.ElectricalConnectionParameterDescriptionData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.ElectricalConnectionParameterDescriptionData = data
+	}
+
+	return success
 }

--- a/model/electricalconnection_additions_test.go
+++ b/model/electricalconnection_additions_test.go
@@ -32,7 +32,8 @@ func TestElectricalConnectionStateListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.ElectricalConnectionStateData
 	// check the non changing items
@@ -156,7 +157,8 @@ func TestElectricalConnectionPermittedValueSetListDataType_Update_Modify(t *test
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.ElectricalConnectionPermittedValueSetData
 	// check the non changing items
@@ -279,7 +281,8 @@ func TestElectricalConnectionPermittedValueSetListDataType_Update_Modify_Selecto
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, partial, nil)
+	success := sut.UpdateList(false, &newData, partial, nil)
+	assert.True(t, success)
 
 	data := sut.ElectricalConnectionPermittedValueSetData
 	// check the non changing items
@@ -442,7 +445,8 @@ func TestElectricalConnectionPermittedValueSetListDataType_Update_Delete_Modify(
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), deleteFilter)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), deleteFilter)
+	assert.True(t, success)
 
 	data := sut.ElectricalConnectionPermittedValueSetData
 	// check the deleted item is gone
@@ -538,7 +542,8 @@ func TestElectricalConnectionPermittedValueSetListDataType_Update_Delete(t *test
 	}
 
 	// Act
-	sut.UpdateList(false, nil, nil, deleteFilter)
+	success := sut.UpdateList(false, nil, nil, deleteFilter)
+	assert.True(t, success)
 
 	data := sut.ElectricalConnectionPermittedValueSetData
 	// check the deleted item is added again
@@ -637,7 +642,8 @@ func TestElectricalConnectionPermittedValueSetListDataType_Update_Delete_Element
 	}
 
 	// Act
-	sut.UpdateList(false, nil, nil, deleteFilter)
+	success := sut.UpdateList(false, nil, nil, deleteFilter)
+	assert.True(t, success)
 
 	data := sut.ElectricalConnectionPermittedValueSetData
 	// check no items are deleted
@@ -739,7 +745,8 @@ func TestElectricalConnectionPermittedValueSetListDataType_Update_Delete_OnlyEle
 	}
 
 	// Act
-	sut.UpdateList(false, nil, nil, deleteFilter)
+	success := sut.UpdateList(false, nil, nil, deleteFilter)
+	assert.True(t, success)
 
 	data := sut.ElectricalConnectionPermittedValueSetData
 	// check no items are deleted
@@ -913,7 +920,8 @@ func TestElectricalConnectionPermittedValueSetListDataType_Update_Delete_Add(t *
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), deleteFilter)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), deleteFilter)
+	assert.True(t, success)
 
 	data := sut.ElectricalConnectionPermittedValueSetData
 	// check the deleted item is added again
@@ -995,7 +1003,8 @@ func TestElectricalConnectionPermittedValueSetListDataType_Update_NewItem(t *tes
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.ElectricalConnectionPermittedValueSetData
 	// new item should be added
@@ -1077,7 +1086,8 @@ func TestElectricalConnectionPermittedValueSetListDataType_UpdateWithoutIdenifie
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.ElectricalConnectionPermittedValueSetData
 	// the new item should not be added
@@ -1131,7 +1141,8 @@ func TestElectricalConnectionDescriptionListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.ElectricalConnectionDescriptionData
 	// check the non changing items
@@ -1175,7 +1186,8 @@ func TestElectricalConnectionCharacteristicListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.ElectricalConnectionCharacteristicData
 	// check the non changing items
@@ -1217,7 +1229,8 @@ func TestElectricalConnectionParameterDescriptionListDataType_Update(t *testing.
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.ElectricalConnectionParameterDescriptionData
 	// check the non changing items

--- a/model/hvac_additions.go
+++ b/model/hvac_additions.go
@@ -4,102 +4,150 @@ package model
 
 var _ Updater = (*HvacSystemFunctionListDataType)(nil)
 
-func (r *HvacSystemFunctionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *HvacSystemFunctionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []HvacSystemFunctionDataType
 	if newList != nil {
 		newData = newList.(*HvacSystemFunctionListDataType).HvacSystemFunctionData
 	}
 
-	r.HvacSystemFunctionData = UpdateList(remoteWrite, r.HvacSystemFunctionData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.HvacSystemFunctionData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.HvacSystemFunctionData = data
+	}
+
+	return success
 }
 
 // HvacSystemFunctionOperationModeRelationListDataType
 
 var _ Updater = (*HvacSystemFunctionOperationModeRelationListDataType)(nil)
 
-func (r *HvacSystemFunctionOperationModeRelationListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *HvacSystemFunctionOperationModeRelationListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []HvacSystemFunctionOperationModeRelationDataType
 	if newList != nil {
 		newData = newList.(*HvacSystemFunctionOperationModeRelationListDataType).HvacSystemFunctionOperationModeRelationData
 	}
 
-	r.HvacSystemFunctionOperationModeRelationData = UpdateList(remoteWrite, r.HvacSystemFunctionOperationModeRelationData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.HvacSystemFunctionOperationModeRelationData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.HvacSystemFunctionOperationModeRelationData = data
+	}
+
+	return success
 }
 
 // HvacSystemFunctionSetpointRelationListDataType
 
 var _ Updater = (*HvacSystemFunctionSetpointRelationListDataType)(nil)
 
-func (r *HvacSystemFunctionSetpointRelationListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *HvacSystemFunctionSetpointRelationListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []HvacSystemFunctionSetpointRelationDataType
 	if newList != nil {
 		newData = newList.(*HvacSystemFunctionSetpointRelationListDataType).HvacSystemFunctionSetpointRelationData
 	}
 
-	r.HvacSystemFunctionSetpointRelationData = UpdateList(remoteWrite, r.HvacSystemFunctionSetpointRelationData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.HvacSystemFunctionSetpointRelationData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.HvacSystemFunctionSetpointRelationData = data
+	}
+
+	return success
 }
 
 // HvacSystemFunctionPowerSequenceRelationListDataType
 
 var _ Updater = (*HvacSystemFunctionPowerSequenceRelationListDataType)(nil)
 
-func (r *HvacSystemFunctionPowerSequenceRelationListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *HvacSystemFunctionPowerSequenceRelationListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []HvacSystemFunctionPowerSequenceRelationDataType
 	if newList != nil {
 		newData = newList.(*HvacSystemFunctionPowerSequenceRelationListDataType).HvacSystemFunctionPowerSequenceRelationData
 	}
 
-	r.HvacSystemFunctionPowerSequenceRelationData = UpdateList(remoteWrite, r.HvacSystemFunctionPowerSequenceRelationData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.HvacSystemFunctionPowerSequenceRelationData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.HvacSystemFunctionPowerSequenceRelationData = data
+	}
+
+	return success
 }
 
 // HvacSystemFunctionDescriptionListDataType
 
 var _ Updater = (*HvacSystemFunctionDescriptionListDataType)(nil)
 
-func (r *HvacSystemFunctionDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *HvacSystemFunctionDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []HvacSystemFunctionDescriptionDataType
 	if newList != nil {
 		newData = newList.(*HvacSystemFunctionDescriptionListDataType).HvacSystemFunctionDescriptionData
 	}
 
-	r.HvacSystemFunctionDescriptionData = UpdateList(remoteWrite, r.HvacSystemFunctionDescriptionData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.HvacSystemFunctionDescriptionData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.HvacSystemFunctionDescriptionData = data
+	}
+
+	return success
 }
 
 // HvacOperationModeDescriptionListDataType
 
 var _ Updater = (*HvacOperationModeDescriptionListDataType)(nil)
 
-func (r *HvacOperationModeDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *HvacOperationModeDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []HvacOperationModeDescriptionDataType
 	if newList != nil {
 		newData = newList.(*HvacOperationModeDescriptionListDataType).HvacOperationModeDescriptionData
 	}
 
-	r.HvacOperationModeDescriptionData = UpdateList(remoteWrite, r.HvacOperationModeDescriptionData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.HvacOperationModeDescriptionData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.HvacOperationModeDescriptionData = data
+	}
+
+	return success
 }
 
 // HvacOverrunListDataType
 
 var _ Updater = (*HvacOverrunListDataType)(nil)
 
-func (r *HvacOverrunListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *HvacOverrunListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []HvacOverrunDataType
 	if newList != nil {
 		newData = newList.(*HvacOverrunListDataType).HvacOverrunData
 	}
 
-	r.HvacOverrunData = UpdateList(remoteWrite, r.HvacOverrunData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.HvacOverrunData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.HvacOverrunData = data
+	}
+
+	return success
 }
 
 // HvacOverrunDescriptionListDataType
 
 var _ Updater = (*HvacOverrunDescriptionListDataType)(nil)
 
-func (r *HvacOverrunDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *HvacOverrunDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []HvacOverrunDescriptionDataType
 	if newList != nil {
 		newData = newList.(*HvacOverrunDescriptionListDataType).HvacOverrunDescriptionData
 	}
 
-	r.HvacOverrunDescriptionData = UpdateList(remoteWrite, r.HvacOverrunDescriptionData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.HvacOverrunDescriptionData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.HvacOverrunDescriptionData = data
+	}
+
+	return success
 }

--- a/model/hvac_additions_test.go
+++ b/model/hvac_additions_test.go
@@ -31,7 +31,8 @@ func TestHvacSystemFunctionListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.HvacSystemFunctionData
 	// check the non changing items
@@ -69,7 +70,8 @@ func TestHvacSystemFunctionOperationModeRelationListDataType_Update(t *testing.T
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.HvacSystemFunctionOperationModeRelationData
 	// check the non changing items
@@ -107,7 +109,8 @@ func TestHvacSystemFunctionSetpointRelationListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.HvacSystemFunctionSetpointRelationData
 	// check the non changing items
@@ -145,7 +148,8 @@ func TestHvacSystemFunctionPowerSequenceRelationListDataType_Update(t *testing.T
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.HvacSystemFunctionPowerSequenceRelationData
 	// check the non changing items
@@ -183,7 +187,8 @@ func TestHvacSystemFunctionDescriptionListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.HvacSystemFunctionDescriptionData
 	// check the non changing items
@@ -221,7 +226,8 @@ func TestHvacOperationModeDescriptionListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.HvacOperationModeDescriptionData
 	// check the non changing items
@@ -259,7 +265,8 @@ func TestHvacOverrunListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.HvacOverrunData
 	// check the non changing items
@@ -297,7 +304,8 @@ func TestHvacOverrunDescriptionListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.HvacOverrunDescriptionData
 	// check the non changing items

--- a/model/identification_additions.go
+++ b/model/identification_additions.go
@@ -4,37 +4,55 @@ package model
 
 var _ Updater = (*IdentificationListDataType)(nil)
 
-func (r *IdentificationListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *IdentificationListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []IdentificationDataType
 	if newList != nil {
 		newData = newList.(*IdentificationListDataType).IdentificationData
 	}
 
-	r.IdentificationData = UpdateList(remoteWrite, r.IdentificationData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.IdentificationData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.IdentificationData = data
+	}
+
+	return success
 }
 
 // SessionIdentificationListDataType
 
 var _ Updater = (*SessionIdentificationListDataType)(nil)
 
-func (r *SessionIdentificationListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *SessionIdentificationListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []SessionIdentificationDataType
 	if newList != nil {
 		newData = newList.(*SessionIdentificationListDataType).SessionIdentificationData
 	}
 
-	r.SessionIdentificationData = UpdateList(remoteWrite, r.SessionIdentificationData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.SessionIdentificationData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.SessionIdentificationData = data
+	}
+
+	return success
 }
 
 // SessionMeasurementRelationListDataType
 
 var _ Updater = (*SessionMeasurementRelationListDataType)(nil)
 
-func (r *SessionMeasurementRelationListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *SessionMeasurementRelationListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []SessionMeasurementRelationDataType
 	if newList != nil {
 		newData = newList.(*SessionMeasurementRelationListDataType).SessionMeasurementRelationData
 	}
 
-	r.SessionMeasurementRelationData = UpdateList(remoteWrite, r.SessionMeasurementRelationData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.SessionMeasurementRelationData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.SessionMeasurementRelationData = data
+	}
+
+	return success
 }

--- a/model/identification_additions_test.go
+++ b/model/identification_additions_test.go
@@ -31,7 +31,8 @@ func TestIdentificationListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.IdentificationData
 	// check the non changing items
@@ -72,7 +73,8 @@ func TestSessionIdentificationListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.SessionIdentificationData
 	// check the non changing items
@@ -116,7 +118,8 @@ func TestSessionMeasurementRelationListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.SessionMeasurementRelationData
 	// check the non changing items

--- a/model/loadcontrol_additions.go
+++ b/model/loadcontrol_additions.go
@@ -4,63 +4,93 @@ package model
 
 var _ Updater = (*LoadControlEventListDataType)(nil)
 
-func (r *LoadControlEventListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *LoadControlEventListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []LoadControlEventDataType
 	if newList != nil {
 		newData = newList.(*LoadControlEventListDataType).LoadControlEventData
 	}
 
-	r.LoadControlEventData = UpdateList(remoteWrite, r.LoadControlEventData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.LoadControlEventData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.LoadControlEventData = data
+	}
+
+	return success
 }
 
 // LoadControlStateListDataType
 
 var _ Updater = (*LoadControlStateListDataType)(nil)
 
-func (r *LoadControlStateListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *LoadControlStateListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []LoadControlStateDataType
 	if newList != nil {
 		newData = newList.(*LoadControlStateListDataType).LoadControlStateData
 	}
 
-	r.LoadControlStateData = UpdateList(remoteWrite, r.LoadControlStateData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.LoadControlStateData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.LoadControlStateData = data
+	}
+
+	return success
 }
 
 // LoadControlLimitListDataType
 
 var _ Updater = (*LoadControlLimitListDataType)(nil)
 
-func (r *LoadControlLimitListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *LoadControlLimitListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []LoadControlLimitDataType
 	if newList != nil {
 		newData = newList.(*LoadControlLimitListDataType).LoadControlLimitData
 	}
 
-	r.LoadControlLimitData = UpdateList(remoteWrite, r.LoadControlLimitData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.LoadControlLimitData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.LoadControlLimitData = data
+	}
+
+	return success
 }
 
 // LoadControlLimitConstraintsListDataType
 
 var _ Updater = (*LoadControlLimitConstraintsListDataType)(nil)
 
-func (r *LoadControlLimitConstraintsListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *LoadControlLimitConstraintsListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []LoadControlLimitConstraintsDataType
 	if newList != nil {
 		newData = newList.(*LoadControlLimitConstraintsListDataType).LoadControlLimitConstraintsData
 	}
 
-	r.LoadControlLimitConstraintsData = UpdateList(remoteWrite, r.LoadControlLimitConstraintsData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.LoadControlLimitConstraintsData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.LoadControlLimitConstraintsData = data
+	}
+
+	return success
 }
 
 // LoadControlLimitDescriptionListDataType
 
 var _ Updater = (*LoadControlLimitDescriptionListDataType)(nil)
 
-func (r *LoadControlLimitDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *LoadControlLimitDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []LoadControlLimitDescriptionDataType
 	if newList != nil {
 		newData = newList.(*LoadControlLimitDescriptionListDataType).LoadControlLimitDescriptionData
 	}
 
-	r.LoadControlLimitDescriptionData = UpdateList(remoteWrite, r.LoadControlLimitDescriptionData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.LoadControlLimitDescriptionData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.LoadControlLimitDescriptionData = data
+	}
+
+	return success
 }

--- a/model/loadcontrol_additions_test.go
+++ b/model/loadcontrol_additions_test.go
@@ -31,7 +31,8 @@ func TestLoadControlEventListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.LoadControlEventData
 	// check the non changing items
@@ -69,7 +70,8 @@ func TestLoadControlStateListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.LoadControlStateData
 	// check the non changing items
@@ -108,18 +110,19 @@ func TestLoadControlLimitListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.LoadControlLimitData
 	// check the non changing items
 	assert.Equal(t, 2, len(data))
 	item1 := data[0]
 	assert.Equal(t, 0, int(*item1.LimitId))
-	assert.Equal(t, false, *item1.IsLimitChangeable)
+	assert.False(t, *item1.IsLimitChangeable)
 	// check properties of updated item
 	item2 := data[1]
 	assert.Equal(t, 1, int(*item2.LimitId))
-	assert.Equal(t, true, *item2.IsLimitChangeable)
+	assert.True(t, *item2.IsLimitChangeable)
 	assert.Equal(t, 10.0, item2.Value.GetValue())
 }
 
@@ -147,7 +150,8 @@ func TestLoadControlLimitConstraintsListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.LoadControlLimitConstraintsData
 	// check the non changing items
@@ -185,7 +189,8 @@ func TestLoadControlLimitDescriptionListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.LoadControlLimitDescriptionData
 	// check the non changing items

--- a/model/measurement_additions.go
+++ b/model/measurement_additions.go
@@ -4,63 +4,93 @@ package model
 
 var _ Updater = (*MeasurementListDataType)(nil)
 
-func (r *MeasurementListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *MeasurementListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []MeasurementDataType
 	if newList != nil {
 		newData = newList.(*MeasurementListDataType).MeasurementData
 	}
 
-	r.MeasurementData = UpdateList(remoteWrite, r.MeasurementData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.MeasurementData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.MeasurementData = data
+	}
+
+	return success
 }
 
 // MeasurementSeriesListDataType
 
 var _ Updater = (*MeasurementSeriesListDataType)(nil)
 
-func (r *MeasurementSeriesListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *MeasurementSeriesListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []MeasurementSeriesDataType
 	if newList != nil {
 		newData = newList.(*MeasurementSeriesListDataType).MeasurementSeriesData
 	}
 
-	r.MeasurementSeriesData = UpdateList(remoteWrite, r.MeasurementSeriesData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.MeasurementSeriesData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.MeasurementSeriesData = data
+	}
+
+	return success
 }
 
 // MeasurementConstraintsListDataType
 
 var _ Updater = (*MeasurementConstraintsListDataType)(nil)
 
-func (r *MeasurementConstraintsListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *MeasurementConstraintsListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []MeasurementConstraintsDataType
 	if newList != nil {
 		newData = newList.(*MeasurementConstraintsListDataType).MeasurementConstraintsData
 	}
 
-	r.MeasurementConstraintsData = UpdateList(remoteWrite, r.MeasurementConstraintsData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.MeasurementConstraintsData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.MeasurementConstraintsData = data
+	}
+
+	return success
 }
 
 // MeasurementDescriptionListDataType
 
 var _ Updater = (*MeasurementDescriptionListDataType)(nil)
 
-func (r *MeasurementDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *MeasurementDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []MeasurementDescriptionDataType
 	if newList != nil {
 		newData = newList.(*MeasurementDescriptionListDataType).MeasurementDescriptionData
 	}
 
-	r.MeasurementDescriptionData = UpdateList(remoteWrite, r.MeasurementDescriptionData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.MeasurementDescriptionData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.MeasurementDescriptionData = data
+	}
+
+	return success
 }
 
 // MeasurementThresholdRelationListDataType
 
 var _ Updater = (*MeasurementThresholdRelationListDataType)(nil)
 
-func (r *MeasurementThresholdRelationListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *MeasurementThresholdRelationListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []MeasurementThresholdRelationDataType
 	if newList != nil {
 		newData = newList.(*MeasurementThresholdRelationListDataType).MeasurementThresholdRelationData
 	}
 
-	r.MeasurementThresholdRelationData = UpdateList(remoteWrite, r.MeasurementThresholdRelationData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.MeasurementThresholdRelationData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.MeasurementThresholdRelationData = data
+	}
+
+	return success
 }

--- a/model/measurement_additions_test.go
+++ b/model/measurement_additions_test.go
@@ -34,7 +34,8 @@ func TestMeasurementListDataType_Update_Add(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.MeasurementData
 	// check the non changing items
@@ -76,7 +77,8 @@ func TestMeasurementListDataType_Update_Replace(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.MeasurementData
 	// check the non changing items
@@ -119,7 +121,8 @@ func TestMeasurementSeriesListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.MeasurementSeriesData
 	// check the non changing items
@@ -157,7 +160,8 @@ func TestMeasurementConstraintsListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.MeasurementConstraintsData
 	// check the non changing items
@@ -195,7 +199,8 @@ func TestMeasurementDescriptionListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.MeasurementDescriptionData
 	// check the non changing items
@@ -233,7 +238,8 @@ func TestMeasurementThresholdRelationListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.MeasurementThresholdRelationData
 	// check the non changing items

--- a/model/messaging_additions.go
+++ b/model/messaging_additions.go
@@ -4,11 +4,17 @@ package model
 
 var _ Updater = (*MessagingListDataType)(nil)
 
-func (r *MessagingListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *MessagingListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []MessagingDataType
 	if newList != nil {
 		newData = newList.(*MessagingListDataType).MessagingData
 	}
 
-	r.MessagingData = UpdateList(remoteWrite, r.MessagingData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.MessagingData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.MessagingData = data
+	}
+
+	return success
 }

--- a/model/messaging_additions_test.go
+++ b/model/messaging_additions_test.go
@@ -31,7 +31,8 @@ func TestMessagingListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.MessagingData
 	// check the non changing items

--- a/model/networkmanagement_additions.go
+++ b/model/networkmanagement_additions.go
@@ -4,37 +4,55 @@ package model
 
 var _ Updater = (*NetworkManagementDeviceDescriptionListDataType)(nil)
 
-func (r *NetworkManagementDeviceDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *NetworkManagementDeviceDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []NetworkManagementDeviceDescriptionDataType
 	if newList != nil {
 		newData = newList.(*NetworkManagementDeviceDescriptionListDataType).NetworkManagementDeviceDescriptionData
 	}
 
-	r.NetworkManagementDeviceDescriptionData = UpdateList(remoteWrite, r.NetworkManagementDeviceDescriptionData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.NetworkManagementDeviceDescriptionData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.NetworkManagementDeviceDescriptionData = data
+	}
+
+	return success
 }
 
 // NetworkManagementEntityDescriptionListDataType
 
 var _ Updater = (*NetworkManagementEntityDescriptionListDataType)(nil)
 
-func (r *NetworkManagementEntityDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *NetworkManagementEntityDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []NetworkManagementEntityDescriptionDataType
 	if newList != nil {
 		newData = newList.(*NetworkManagementEntityDescriptionListDataType).NetworkManagementEntityDescriptionData
 	}
 
-	r.NetworkManagementEntityDescriptionData = UpdateList(remoteWrite, r.NetworkManagementEntityDescriptionData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.NetworkManagementEntityDescriptionData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.NetworkManagementEntityDescriptionData = data
+	}
+
+	return success
 }
 
 // NetworkManagementFeatureDescriptionListDataType
 
 var _ Updater = (*NetworkManagementFeatureDescriptionListDataType)(nil)
 
-func (r *NetworkManagementFeatureDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *NetworkManagementFeatureDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []NetworkManagementFeatureDescriptionDataType
 	if newList != nil {
 		newData = newList.(*NetworkManagementFeatureDescriptionListDataType).NetworkManagementFeatureDescriptionData
 	}
 
-	r.NetworkManagementFeatureDescriptionData = UpdateList(remoteWrite, r.NetworkManagementFeatureDescriptionData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.NetworkManagementFeatureDescriptionData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.NetworkManagementFeatureDescriptionData = data
+	}
+
+	return success
 }

--- a/model/networkmanagement_additions_test.go
+++ b/model/networkmanagement_additions_test.go
@@ -37,7 +37,8 @@ func TestNetworkManagementDeviceDescriptionListDataType(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.NetworkManagementDeviceDescriptionData
 	// check the non changing items
@@ -82,7 +83,8 @@ func TestNetworkManagementEntityDescriptionListDataType(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.NetworkManagementEntityDescriptionData
 	// check the non changing items
@@ -130,7 +132,8 @@ func TestNetworkManagementFeatureDescriptionListDataType(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.NetworkManagementFeatureDescriptionData
 	// check the non changing items

--- a/model/nodemanagement_additions.go
+++ b/model/nodemanagement_additions.go
@@ -13,13 +13,19 @@ var nmMux sync.Mutex
 
 var _ Updater = (*NodeManagementDestinationListDataType)(nil)
 
-func (r *NodeManagementDestinationListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *NodeManagementDestinationListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []NodeManagementDestinationDataType
 	if newList != nil {
 		newData = newList.(*NodeManagementDestinationListDataType).NodeManagementDestinationData
 	}
 
-	r.NodeManagementDestinationData = UpdateList(remoteWrite, r.NodeManagementDestinationData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.NodeManagementDestinationData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.NodeManagementDestinationData = data
+	}
+
+	return success
 }
 
 // NodeManagementUseCaseDataType

--- a/model/nodemanagement_additions_test.go
+++ b/model/nodemanagement_additions_test.go
@@ -16,11 +16,6 @@ type NodeManagementUseCaseDataTypeSuite struct {
 	suite.Suite
 }
 
-func (s *NodeManagementUseCaseDataTypeSuite) SetupSuite()   {}
-func (s *NodeManagementUseCaseDataTypeSuite) TearDownTest() {}
-
-func (s *NodeManagementUseCaseDataTypeSuite) BeforeTest(suiteName, testName string) {}
-
 func (s *NodeManagementUseCaseDataTypeSuite) Test_AdditionsAndRemovals() {
 	ucs := &NodeManagementUseCaseDataType{}
 	assert.NotNil(s.T(), ucs)

--- a/model/operatingconstraints_additions.go
+++ b/model/operatingconstraints_additions.go
@@ -4,76 +4,112 @@ package model
 
 var _ Updater = (*OperatingConstraintsInterruptListDataType)(nil)
 
-func (r *OperatingConstraintsInterruptListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *OperatingConstraintsInterruptListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []OperatingConstraintsInterruptDataType
 	if newList != nil {
 		newData = newList.(*OperatingConstraintsInterruptListDataType).OperatingConstraintsInterruptData
 	}
 
-	r.OperatingConstraintsInterruptData = UpdateList(remoteWrite, r.OperatingConstraintsInterruptData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.OperatingConstraintsInterruptData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.OperatingConstraintsInterruptData = data
+	}
+
+	return success
 }
 
 // OperatingConstraintsDurationListDataType
 
 var _ Updater = (*OperatingConstraintsDurationListDataType)(nil)
 
-func (r *OperatingConstraintsDurationListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *OperatingConstraintsDurationListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []OperatingConstraintsDurationDataType
 	if newList != nil {
 		newData = newList.(*OperatingConstraintsDurationListDataType).OperatingConstraintsDurationData
 	}
 
-	r.OperatingConstraintsDurationData = UpdateList(remoteWrite, r.OperatingConstraintsDurationData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.OperatingConstraintsDurationData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.OperatingConstraintsDurationData = data
+	}
+
+	return success
 }
 
 // OperatingConstraintsPowerDescriptionListDataType
 
 var _ Updater = (*OperatingConstraintsPowerDescriptionListDataType)(nil)
 
-func (r *OperatingConstraintsPowerDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *OperatingConstraintsPowerDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []OperatingConstraintsPowerDescriptionDataType
 	if newList != nil {
 		newData = newList.(*OperatingConstraintsPowerDescriptionListDataType).OperatingConstraintsPowerDescriptionData
 	}
 
-	r.OperatingConstraintsPowerDescriptionData = UpdateList(remoteWrite, r.OperatingConstraintsPowerDescriptionData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.OperatingConstraintsPowerDescriptionData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.OperatingConstraintsPowerDescriptionData = data
+	}
+
+	return success
 }
 
 // OperatingConstraintsPowerRangeListDataType
 
 var _ Updater = (*OperatingConstraintsPowerRangeListDataType)(nil)
 
-func (r *OperatingConstraintsPowerRangeListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *OperatingConstraintsPowerRangeListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []OperatingConstraintsPowerRangeDataType
 	if newList != nil {
 		newData = newList.(*OperatingConstraintsPowerRangeListDataType).OperatingConstraintsPowerRangeData
 	}
 
-	r.OperatingConstraintsPowerRangeData = UpdateList(remoteWrite, r.OperatingConstraintsPowerRangeData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.OperatingConstraintsPowerRangeData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.OperatingConstraintsPowerRangeData = data
+	}
+
+	return success
 }
 
 // OperatingConstraintsPowerLevelListDataType
 
 var _ Updater = (*OperatingConstraintsPowerLevelListDataType)(nil)
 
-func (r *OperatingConstraintsPowerLevelListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *OperatingConstraintsPowerLevelListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []OperatingConstraintsPowerLevelDataType
 	if newList != nil {
 		newData = newList.(*OperatingConstraintsPowerLevelListDataType).OperatingConstraintsPowerLevelData
 	}
 
-	r.OperatingConstraintsPowerLevelData = UpdateList(remoteWrite, r.OperatingConstraintsPowerLevelData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.OperatingConstraintsPowerLevelData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.OperatingConstraintsPowerLevelData = data
+	}
+
+	return success
 }
 
 // OperatingConstraintsResumeImplicationListDataType
 
 var _ Updater = (*OperatingConstraintsResumeImplicationListDataType)(nil)
 
-func (r *OperatingConstraintsResumeImplicationListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *OperatingConstraintsResumeImplicationListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []OperatingConstraintsResumeImplicationDataType
 	if newList != nil {
 		newData = newList.(*OperatingConstraintsResumeImplicationListDataType).OperatingConstraintsResumeImplicationData
 	}
 
-	r.OperatingConstraintsResumeImplicationData = UpdateList(remoteWrite, r.OperatingConstraintsResumeImplicationData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.OperatingConstraintsResumeImplicationData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.OperatingConstraintsResumeImplicationData = data
+	}
+
+	return success
 }

--- a/model/operatingconstraints_additions_test.go
+++ b/model/operatingconstraints_additions_test.go
@@ -32,7 +32,8 @@ func TestOperatingConstraintsInterruptListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.OperatingConstraintsInterruptData
 	// check the non changing items
@@ -70,7 +71,8 @@ func TestOperatingConstraintsDurationListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.OperatingConstraintsDurationData
 	// check the non changing items
@@ -110,7 +112,8 @@ func TestOperatingConstraintsPowerDescriptionListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.OperatingConstraintsPowerDescriptionData
 	// check the non changing items
@@ -148,7 +151,8 @@ func TestOperatingConstraintsPowerRangeListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.OperatingConstraintsPowerRangeData
 	// check the non changing items
@@ -186,7 +190,8 @@ func TestOperatingConstraintsPowerLevelListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.OperatingConstraintsPowerLevelData
 	// check the non changing items
@@ -224,7 +229,8 @@ func TestOperatingConstraintsResumeImplicationListDataType_Update(t *testing.T) 
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.OperatingConstraintsResumeImplicationData
 	// check the non changing items

--- a/model/powersequences_additions.go
+++ b/model/powersequences_additions.go
@@ -4,128 +4,188 @@ package model
 
 var _ Updater = (*PowerTimeSlotScheduleListDataType)(nil)
 
-func (r *PowerTimeSlotScheduleListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *PowerTimeSlotScheduleListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []PowerTimeSlotScheduleDataType
 	if newList != nil {
 		newData = newList.(*PowerTimeSlotScheduleListDataType).PowerTimeSlotScheduleData
 	}
 
-	r.PowerTimeSlotScheduleData = UpdateList(remoteWrite, r.PowerTimeSlotScheduleData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.PowerTimeSlotScheduleData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.PowerTimeSlotScheduleData = data
+	}
+
+	return success
 }
 
 // PowerTimeSlotValueListDataType
 
 var _ Updater = (*PowerTimeSlotValueListDataType)(nil)
 
-func (r *PowerTimeSlotValueListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *PowerTimeSlotValueListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []PowerTimeSlotValueDataType
 	if newList != nil {
 		newData = newList.(*PowerTimeSlotValueListDataType).PowerTimeSlotValueData
 	}
 
-	r.PowerTimeSlotValueData = UpdateList(remoteWrite, r.PowerTimeSlotValueData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.PowerTimeSlotValueData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.PowerTimeSlotValueData = data
+	}
+
+	return success
 }
 
 // PowerTimeSlotScheduleConstraintsListDataType
 
 var _ Updater = (*PowerTimeSlotScheduleConstraintsListDataType)(nil)
 
-func (r *PowerTimeSlotScheduleConstraintsListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *PowerTimeSlotScheduleConstraintsListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []PowerTimeSlotScheduleConstraintsDataType
 	if newList != nil {
 		newData = newList.(*PowerTimeSlotScheduleConstraintsListDataType).PowerTimeSlotScheduleConstraintsData
 	}
 
-	r.PowerTimeSlotScheduleConstraintsData = UpdateList(remoteWrite, r.PowerTimeSlotScheduleConstraintsData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.PowerTimeSlotScheduleConstraintsData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.PowerTimeSlotScheduleConstraintsData = data
+	}
+
+	return success
 }
 
 // PowerSequenceAlternativesRelationListDataType
 
 var _ Updater = (*PowerSequenceAlternativesRelationListDataType)(nil)
 
-func (r *PowerSequenceAlternativesRelationListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *PowerSequenceAlternativesRelationListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []PowerSequenceAlternativesRelationDataType
 	if newList != nil {
 		newData = newList.(*PowerSequenceAlternativesRelationListDataType).PowerSequenceAlternativesRelationData
 	}
 
-	r.PowerSequenceAlternativesRelationData = UpdateList(remoteWrite, r.PowerSequenceAlternativesRelationData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.PowerSequenceAlternativesRelationData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.PowerSequenceAlternativesRelationData = data
+	}
+
+	return success
 }
 
 // PowerSequenceDescriptionListDataType
 
 var _ Updater = (*PowerSequenceDescriptionListDataType)(nil)
 
-func (r *PowerSequenceDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *PowerSequenceDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []PowerSequenceDescriptionDataType
 	if newList != nil {
 		newData = newList.(*PowerSequenceDescriptionListDataType).PowerSequenceDescriptionData
 	}
 
-	r.PowerSequenceDescriptionData = UpdateList(remoteWrite, r.PowerSequenceDescriptionData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.PowerSequenceDescriptionData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.PowerSequenceDescriptionData = data
+	}
+
+	return success
 }
 
 // PowerSequenceStateListDataType
 
 var _ Updater = (*PowerSequenceStateListDataType)(nil)
 
-func (r *PowerSequenceStateListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *PowerSequenceStateListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []PowerSequenceStateDataType
 	if newList != nil {
 		newData = newList.(*PowerSequenceStateListDataType).PowerSequenceStateData
 	}
 
-	r.PowerSequenceStateData = UpdateList(remoteWrite, r.PowerSequenceStateData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.PowerSequenceStateData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.PowerSequenceStateData = data
+	}
+
+	return success
 }
 
 // PowerSequenceScheduleListDataType
 
 var _ Updater = (*PowerSequenceScheduleListDataType)(nil)
 
-func (r *PowerSequenceScheduleListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *PowerSequenceScheduleListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []PowerSequenceScheduleDataType
 	if newList != nil {
 		newData = newList.(*PowerSequenceScheduleListDataType).PowerSequenceScheduleData
 	}
 
-	r.PowerSequenceScheduleData = UpdateList(remoteWrite, r.PowerSequenceScheduleData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.PowerSequenceScheduleData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.PowerSequenceScheduleData = data
+	}
+
+	return success
 }
 
 // PowerSequenceScheduleConstraintsListDataType
 
 var _ Updater = (*PowerSequenceScheduleConstraintsListDataType)(nil)
 
-func (r *PowerSequenceScheduleConstraintsListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *PowerSequenceScheduleConstraintsListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []PowerSequenceScheduleConstraintsDataType
 	if newList != nil {
 		newData = newList.(*PowerSequenceScheduleConstraintsListDataType).PowerSequenceScheduleConstraintsData
 	}
 
-	r.PowerSequenceScheduleConstraintsData = UpdateList(remoteWrite, r.PowerSequenceScheduleConstraintsData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.PowerSequenceScheduleConstraintsData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.PowerSequenceScheduleConstraintsData = data
+	}
+
+	return success
 }
 
 // PowerSequencePriceListDataType
 
 var _ Updater = (*PowerSequencePriceListDataType)(nil)
 
-func (r *PowerSequencePriceListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *PowerSequencePriceListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []PowerSequencePriceDataType
 	if newList != nil {
 		newData = newList.(*PowerSequencePriceListDataType).PowerSequencePriceData
 	}
 
-	r.PowerSequencePriceData = UpdateList(remoteWrite, r.PowerSequencePriceData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.PowerSequencePriceData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.PowerSequencePriceData = data
+	}
+
+	return success
 }
 
 // PowerSequenceSchedulePreferenceListDataType
 
 var _ Updater = (*PowerSequenceSchedulePreferenceListDataType)(nil)
 
-func (r *PowerSequenceSchedulePreferenceListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *PowerSequenceSchedulePreferenceListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []PowerSequenceSchedulePreferenceDataType
 	if newList != nil {
 		newData = newList.(*PowerSequenceSchedulePreferenceListDataType).PowerSequenceSchedulePreferenceData
 	}
 
-	r.PowerSequenceSchedulePreferenceData = UpdateList(remoteWrite, r.PowerSequenceSchedulePreferenceData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.PowerSequenceSchedulePreferenceData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.PowerSequenceSchedulePreferenceData = data
+	}
+
+	return success
 }

--- a/model/powersequences_additions_test.go
+++ b/model/powersequences_additions_test.go
@@ -32,7 +32,8 @@ func TestPowerTimeSlotScheduleListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.PowerTimeSlotScheduleData
 	// check the non changing items
@@ -70,7 +71,8 @@ func TestPowerTimeSlotValueListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.PowerTimeSlotValueData
 	// check the non changing items
@@ -108,7 +110,8 @@ func TestPowerTimeSlotScheduleConstraintsListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.PowerTimeSlotScheduleConstraintsData
 	// check the non changing items
@@ -148,7 +151,8 @@ func TestPowerSequenceAlternativesRelationListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.PowerSequenceAlternativesRelationData
 	// check the non changing items
@@ -186,7 +190,8 @@ func TestPowerSequenceDescriptionListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.PowerSequenceDescriptionData
 	// check the non changing items
@@ -224,7 +229,8 @@ func TestPowerSequenceStateListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.PowerSequenceStateData
 	// check the non changing items
@@ -262,7 +268,8 @@ func TestPowerSequenceScheduleListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.PowerSequenceScheduleData
 	// check the non changing items
@@ -300,7 +307,8 @@ func TestPowerSequenceScheduleConstraintsListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.PowerSequenceScheduleConstraintsData
 	// check the non changing items
@@ -338,7 +346,8 @@ func TestPowerSequencePriceListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.PowerSequencePriceData
 	// check the non changing items
@@ -376,7 +385,8 @@ func TestPowerSequenceSchedulePreferenceListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.PowerSequenceSchedulePreferenceData
 	// check the non changing items

--- a/model/setpoint_additions.go
+++ b/model/setpoint_additions.go
@@ -4,24 +4,36 @@ package model
 
 var _ Updater = (*SetpointListDataType)(nil)
 
-func (r *SetpointListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *SetpointListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []SetpointDataType
 	if newList != nil {
 		newData = newList.(*SetpointListDataType).SetpointData
 	}
 
-	r.SetpointData = UpdateList(remoteWrite, r.SetpointData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.SetpointData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.SetpointData = data
+	}
+
+	return success
 }
 
 // SetpointDescriptionListDataType
 
 var _ Updater = (*SetpointDescriptionListDataType)(nil)
 
-func (r *SetpointDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *SetpointDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []SetpointDescriptionDataType
 	if newList != nil {
 		newData = newList.(*SetpointDescriptionListDataType).SetpointDescriptionData
 	}
 
-	r.SetpointDescriptionData = UpdateList(remoteWrite, r.SetpointDescriptionData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.SetpointDescriptionData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.SetpointDescriptionData = data
+	}
+
+	return success
 }

--- a/model/setpoint_additions_test.go
+++ b/model/setpoint_additions_test.go
@@ -31,7 +31,8 @@ func TestSetpointListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.SetpointData
 	// check the non changing items
@@ -69,7 +70,8 @@ func TestSetpointDescriptionListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.SetpointDescriptionData
 	// check the non changing items

--- a/model/stateinformation_additions.go
+++ b/model/stateinformation_additions.go
@@ -4,11 +4,17 @@ package model
 
 var _ Updater = (*StateInformationListDataType)(nil)
 
-func (r *StateInformationListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *StateInformationListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []StateInformationDataType
 	if newList != nil {
 		newData = newList.(*StateInformationListDataType).StateInformationData
 	}
 
-	r.StateInformationData = UpdateList(remoteWrite, r.StateInformationData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.StateInformationData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.StateInformationData = data
+	}
+
+	return success
 }

--- a/model/stateinformation_additions_test.go
+++ b/model/stateinformation_additions_test.go
@@ -31,7 +31,8 @@ func TestStateInformationListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.StateInformationData
 	// check the non changing items

--- a/model/subscriptionmanagement_additions.go
+++ b/model/subscriptionmanagement_additions.go
@@ -4,11 +4,17 @@ package model
 
 var _ Updater = (*SubscriptionManagementEntryListDataType)(nil)
 
-func (r *SubscriptionManagementEntryListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *SubscriptionManagementEntryListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []SubscriptionManagementEntryDataType
 	if newList != nil {
 		newData = newList.(*SubscriptionManagementEntryListDataType).SubscriptionManagementEntryData
 	}
 
-	r.SubscriptionManagementEntryData = UpdateList(remoteWrite, r.SubscriptionManagementEntryData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.SubscriptionManagementEntryData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.SubscriptionManagementEntryData = data
+	}
+
+	return success
 }

--- a/model/subscriptionmanagement_additions_test.go
+++ b/model/subscriptionmanagement_additions_test.go
@@ -31,7 +31,8 @@ func TestSubscriptionManagementEntryListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.SubscriptionManagementEntryData
 	// check the non changing items

--- a/model/supplyconditions_additions.go
+++ b/model/supplyconditions_additions.go
@@ -4,37 +4,55 @@ package model
 
 var _ Updater = (*SupplyConditionListDataType)(nil)
 
-func (r *SupplyConditionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *SupplyConditionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []SupplyConditionDataType
 	if newList != nil {
 		newData = newList.(*SupplyConditionListDataType).SupplyConditionData
 	}
 
-	r.SupplyConditionData = UpdateList(remoteWrite, r.SupplyConditionData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.SupplyConditionData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.SupplyConditionData = data
+	}
+
+	return success
 }
 
 // SupplyConditionDescriptionListDataType
 
 var _ Updater = (*SupplyConditionDescriptionListDataType)(nil)
 
-func (r *SupplyConditionDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *SupplyConditionDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []SupplyConditionDescriptionDataType
 	if newList != nil {
 		newData = newList.(*SupplyConditionDescriptionListDataType).SupplyConditionDescriptionData
 	}
 
-	r.SupplyConditionDescriptionData = UpdateList(remoteWrite, r.SupplyConditionDescriptionData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.SupplyConditionDescriptionData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.SupplyConditionDescriptionData = data
+	}
+
+	return success
 }
 
 // SupplyConditionThresholdRelationListDataType
 
 var _ Updater = (*SupplyConditionThresholdRelationListDataType)(nil)
 
-func (r *SupplyConditionThresholdRelationListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *SupplyConditionThresholdRelationListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []SupplyConditionThresholdRelationDataType
 	if newList != nil {
 		newData = newList.(*SupplyConditionThresholdRelationListDataType).SupplyConditionThresholdRelationData
 	}
 
-	r.SupplyConditionThresholdRelationData = UpdateList(remoteWrite, r.SupplyConditionThresholdRelationData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.SupplyConditionThresholdRelationData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.SupplyConditionThresholdRelationData = data
+	}
+
+	return success
 }

--- a/model/supplyconditions_additions_test.go
+++ b/model/supplyconditions_additions_test.go
@@ -31,7 +31,8 @@ func TestSupplyConditionListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.SupplyConditionData
 	// check the non changing items
@@ -69,7 +70,8 @@ func TestSupplyConditionDescriptionListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.SupplyConditionDescriptionData
 	// check the non changing items
@@ -107,7 +109,8 @@ func TestSupplyConditionThresholdRelationListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.SupplyConditionThresholdRelationData
 	// check the non changing items

--- a/model/tariffinformation_additions.go
+++ b/model/tariffinformation_additions.go
@@ -4,154 +4,226 @@ package model
 
 var _ Updater = (*TariffListDataType)(nil)
 
-func (r *TariffListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *TariffListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []TariffDataType
 	if newList != nil {
 		newData = newList.(*TariffListDataType).TariffData
 	}
 
-	r.TariffData = UpdateList(remoteWrite, r.TariffData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.TariffData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.TariffData = data
+	}
+
+	return success
 }
 
 // TariffTierRelationListDataType
 
 var _ Updater = (*TariffTierRelationListDataType)(nil)
 
-func (r *TariffTierRelationListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *TariffTierRelationListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []TariffTierRelationDataType
 	if newList != nil {
 		newData = newList.(*TariffTierRelationListDataType).TariffTierRelationData
 	}
 
-	r.TariffTierRelationData = UpdateList(remoteWrite, r.TariffTierRelationData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.TariffTierRelationData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.TariffTierRelationData = data
+	}
+
+	return success
 }
 
 // TariffBoundaryRelationListDataType
 
 var _ Updater = (*TariffBoundaryRelationListDataType)(nil)
 
-func (r *TariffBoundaryRelationListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *TariffBoundaryRelationListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []TariffBoundaryRelationDataType
 	if newList != nil {
 		newData = newList.(*TariffBoundaryRelationListDataType).TariffBoundaryRelationData
 	}
 
-	r.TariffBoundaryRelationData = UpdateList(remoteWrite, r.TariffBoundaryRelationData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.TariffBoundaryRelationData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.TariffBoundaryRelationData = data
+	}
+
+	return success
 }
 
 // TariffDescriptionListDataType
 
 var _ Updater = (*TariffDescriptionListDataType)(nil)
 
-func (r *TariffDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *TariffDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []TariffDescriptionDataType
 	if newList != nil {
 		newData = newList.(*TariffDescriptionListDataType).TariffDescriptionData
 	}
 
-	r.TariffDescriptionData = UpdateList(remoteWrite, r.TariffDescriptionData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.TariffDescriptionData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.TariffDescriptionData = data
+	}
+
+	return success
 }
 
 // TierBoundaryListDataType
 
 var _ Updater = (*TierBoundaryListDataType)(nil)
 
-func (r *TierBoundaryListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *TierBoundaryListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []TierBoundaryDataType
 	if newList != nil {
 		newData = newList.(*TierBoundaryListDataType).TierBoundaryData
 	}
 
-	r.TierBoundaryData = UpdateList(remoteWrite, r.TierBoundaryData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.TierBoundaryData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.TierBoundaryData = data
+	}
+
+	return success
 }
 
 // TierBoundaryDescriptionListDataType
 
 var _ Updater = (*TierBoundaryDescriptionListDataType)(nil)
 
-func (r *TierBoundaryDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *TierBoundaryDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []TierBoundaryDescriptionDataType
 	if newList != nil {
 		newData = newList.(*TierBoundaryDescriptionListDataType).TierBoundaryDescriptionData
 	}
 
-	r.TierBoundaryDescriptionData = UpdateList(remoteWrite, r.TierBoundaryDescriptionData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.TierBoundaryDescriptionData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.TierBoundaryDescriptionData = data
+	}
+
+	return success
 }
 
 // CommodityListDataType
 
 var _ Updater = (*CommodityListDataType)(nil)
 
-func (r *CommodityListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *CommodityListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []CommodityDataType
 	if newList != nil {
 		newData = newList.(*CommodityListDataType).CommodityData
 	}
 
-	r.CommodityData = UpdateList(remoteWrite, r.CommodityData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.CommodityData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.CommodityData = data
+	}
+
+	return success
 }
 
 // TierListDataType
 
 var _ Updater = (*TierListDataType)(nil)
 
-func (r *TierListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *TierListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []TierDataType
 	if newList != nil {
 		newData = newList.(*TierListDataType).TierData
 	}
 
-	r.TierData = UpdateList(remoteWrite, r.TierData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.TierData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.TierData = data
+	}
+
+	return success
 }
 
 // TierIncentiveRelationListDataType
 
 var _ Updater = (*TierIncentiveRelationListDataType)(nil)
 
-func (r *TierIncentiveRelationListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *TierIncentiveRelationListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []TierIncentiveRelationDataType
 	if newList != nil {
 		newData = newList.(*TierIncentiveRelationListDataType).TierIncentiveRelationData
 	}
 
-	r.TierIncentiveRelationData = UpdateList(remoteWrite, r.TierIncentiveRelationData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.TierIncentiveRelationData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.TierIncentiveRelationData = data
+	}
+
+	return success
 }
 
 // TierDescriptionListDataType
 
 var _ Updater = (*TierDescriptionListDataType)(nil)
 
-func (r *TierDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *TierDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []TierDescriptionDataType
 	if newList != nil {
 		newData = newList.(*TierDescriptionListDataType).TierDescriptionData
 	}
 
-	r.TierDescriptionData = UpdateList(remoteWrite, r.TierDescriptionData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.TierDescriptionData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.TierDescriptionData = data
+	}
+
+	return success
 }
 
 // IncentiveListDataType
 
 var _ Updater = (*IncentiveListDataType)(nil)
 
-func (r *IncentiveListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *IncentiveListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []IncentiveDataType
 	if newList != nil {
 		newData = newList.(*IncentiveListDataType).IncentiveData
 	}
 
-	r.IncentiveData = UpdateList(remoteWrite, r.IncentiveData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.IncentiveData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.IncentiveData = data
+	}
+
+	return success
 }
 
 // IncentiveDescriptionListDataType
 
 var _ Updater = (*IncentiveDescriptionListDataType)(nil)
 
-func (r *IncentiveDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *IncentiveDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []IncentiveDescriptionDataType
 	if newList != nil {
 		newData = newList.(*IncentiveDescriptionListDataType).IncentiveDescriptionData
 	}
 
-	r.IncentiveDescriptionData = UpdateList(remoteWrite, r.IncentiveDescriptionData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.IncentiveDescriptionData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.IncentiveDescriptionData = data
+	}
+
+	return success
 }

--- a/model/tariffinformation_additions_test.go
+++ b/model/tariffinformation_additions_test.go
@@ -31,7 +31,8 @@ func TestTariffListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.TariffData
 	// check the non changing items
@@ -69,7 +70,8 @@ func TestTariffTierRelationListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.TariffTierRelationData
 	// check the non changing items
@@ -107,7 +109,8 @@ func TestTariffBoundaryRelationListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.TariffBoundaryRelationData
 	// check the non changing items
@@ -145,7 +148,8 @@ func TestTariffDescriptionListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.TariffDescriptionData
 	// check the non changing items
@@ -183,7 +187,8 @@ func TestTierBoundaryListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.TierBoundaryData
 	// check the non changing items
@@ -221,7 +226,8 @@ func TestTierBoundaryDescriptionListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.TierBoundaryDescriptionData
 	// check the non changing items
@@ -259,7 +265,8 @@ func TestCommodityListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.CommodityData
 	// check the non changing items
@@ -297,7 +304,8 @@ func TestTierListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.TierData
 	// check the non changing items
@@ -335,7 +343,8 @@ func TestTierIncentiveRelationListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.TierIncentiveRelationData
 	// check the non changing items
@@ -373,7 +382,8 @@ func TestTierDescriptionListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.TierDescriptionData
 	// check the non changing items
@@ -411,7 +421,8 @@ func TestIncentiveListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.IncentiveData
 	// check the non changing items
@@ -449,7 +460,8 @@ func TestIncentiveDescriptionListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.IncentiveDescriptionData
 	// check the non changing items

--- a/model/taskmanagement_additions.go
+++ b/model/taskmanagement_additions.go
@@ -4,37 +4,55 @@ package model
 
 var _ Updater = (*TaskManagementJobListDataType)(nil)
 
-func (r *TaskManagementJobListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *TaskManagementJobListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []TaskManagementJobDataType
 	if newList != nil {
 		newData = newList.(*TaskManagementJobListDataType).TaskManagementJobData
 	}
 
-	r.TaskManagementJobData = UpdateList(remoteWrite, r.TaskManagementJobData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.TaskManagementJobData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.TaskManagementJobData = data
+	}
+
+	return success
 }
 
 // TaskManagementJobRelationListDataType
 
 var _ Updater = (*TaskManagementJobRelationListDataType)(nil)
 
-func (r *TaskManagementJobRelationListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *TaskManagementJobRelationListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []TaskManagementJobRelationDataType
 	if newList != nil {
 		newData = newList.(*TaskManagementJobRelationListDataType).TaskManagementJobRelationData
 	}
 
-	r.TaskManagementJobRelationData = UpdateList(remoteWrite, r.TaskManagementJobRelationData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.TaskManagementJobRelationData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.TaskManagementJobRelationData = data
+	}
+
+	return success
 }
 
 // TaskManagementJobDescriptionListDataType
 
 var _ Updater = (*TaskManagementJobDescriptionListDataType)(nil)
 
-func (r *TaskManagementJobDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *TaskManagementJobDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []TaskManagementJobDescriptionDataType
 	if newList != nil {
 		newData = newList.(*TaskManagementJobDescriptionListDataType).TaskManagementJobDescriptionData
 	}
 
-	r.TaskManagementJobDescriptionData = UpdateList(remoteWrite, r.TaskManagementJobDescriptionData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.TaskManagementJobDescriptionData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.TaskManagementJobDescriptionData = data
+	}
+
+	return success
 }

--- a/model/taskmanagement_additions_test.go
+++ b/model/taskmanagement_additions_test.go
@@ -31,7 +31,8 @@ func TestTaskManagementJobListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.TaskManagementJobData
 	// check the non changing items
@@ -75,7 +76,8 @@ func TestTaskManagementJobRelationListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.TaskManagementJobRelationData
 	// check the non changing items
@@ -113,7 +115,8 @@ func TestTaskManagementJobDescriptionListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.TaskManagementJobDescriptionData
 	// check the non changing items

--- a/model/threshold_additions.go
+++ b/model/threshold_additions.go
@@ -4,37 +4,55 @@ package model
 
 var _ Updater = (*ThresholdListDataType)(nil)
 
-func (r *ThresholdListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *ThresholdListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []ThresholdDataType
 	if newList != nil {
 		newData = newList.(*ThresholdListDataType).ThresholdData
 	}
 
-	r.ThresholdData = UpdateList(remoteWrite, r.ThresholdData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.ThresholdData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.ThresholdData = data
+	}
+
+	return success
 }
 
 // ThresholdConstraintsListDataType
 
 var _ Updater = (*ThresholdConstraintsListDataType)(nil)
 
-func (r *ThresholdConstraintsListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *ThresholdConstraintsListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []ThresholdConstraintsDataType
 	if newList != nil {
 		newData = newList.(*ThresholdConstraintsListDataType).ThresholdConstraintsData
 	}
 
-	r.ThresholdConstraintsData = UpdateList(remoteWrite, r.ThresholdConstraintsData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.ThresholdConstraintsData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.ThresholdConstraintsData = data
+	}
+
+	return success
 }
 
 // ThresholdDescriptionListDataType
 
 var _ Updater = (*ThresholdDescriptionListDataType)(nil)
 
-func (r *ThresholdDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *ThresholdDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []ThresholdDescriptionDataType
 	if newList != nil {
 		newData = newList.(*ThresholdDescriptionListDataType).ThresholdDescriptionData
 	}
 
-	r.ThresholdDescriptionData = UpdateList(remoteWrite, r.ThresholdDescriptionData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.ThresholdDescriptionData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.ThresholdDescriptionData = data
+	}
+
+	return success
 }

--- a/model/threshold_additions_test.go
+++ b/model/threshold_additions_test.go
@@ -31,7 +31,8 @@ func TestThresholdListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.ThresholdData
 	// check the non changing items
@@ -69,7 +70,8 @@ func TestThresholdConstraintsListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.ThresholdConstraintsData
 	// check the non changing items
@@ -107,7 +109,8 @@ func TestThresholdDescriptionListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.ThresholdDescriptionData
 	// check the non changing items

--- a/model/timeseries_additions.go
+++ b/model/timeseries_additions.go
@@ -4,37 +4,55 @@ package model
 
 var _ Updater = (*TimeSeriesListDataType)(nil)
 
-func (r *TimeSeriesListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *TimeSeriesListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []TimeSeriesDataType
 	if newList != nil {
 		newData = newList.(*TimeSeriesListDataType).TimeSeriesData
 	}
 
-	r.TimeSeriesData = UpdateList(remoteWrite, r.TimeSeriesData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.TimeSeriesData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.TimeSeriesData = data
+	}
+
+	return success
 }
 
 // TimeSeriesDescriptionListDataType
 
 var _ Updater = (*TimeSeriesDescriptionListDataType)(nil)
 
-func (r *TimeSeriesDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *TimeSeriesDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []TimeSeriesDescriptionDataType
 	if newList != nil {
 		newData = newList.(*TimeSeriesDescriptionListDataType).TimeSeriesDescriptionData
 	}
 
-	r.TimeSeriesDescriptionData = UpdateList(remoteWrite, r.TimeSeriesDescriptionData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.TimeSeriesDescriptionData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.TimeSeriesDescriptionData = data
+	}
+
+	return success
 }
 
 // TimeSeriesConstraintsListDataType
 
 var _ Updater = (*TimeSeriesConstraintsListDataType)(nil)
 
-func (r *TimeSeriesConstraintsListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *TimeSeriesConstraintsListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []TimeSeriesConstraintsDataType
 	if newList != nil {
 		newData = newList.(*TimeSeriesConstraintsListDataType).TimeSeriesConstraintsData
 	}
 
-	r.TimeSeriesConstraintsData = UpdateList(remoteWrite, r.TimeSeriesConstraintsData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.TimeSeriesConstraintsData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.TimeSeriesConstraintsData = data
+	}
+
+	return success
 }

--- a/model/timeseries_additions_test.go
+++ b/model/timeseries_additions_test.go
@@ -43,7 +43,8 @@ func TestTimeSeriesListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.TimeSeriesData
 	// check the non changing items
@@ -147,7 +148,8 @@ func TestTimeSeriesListDataType_Update_02(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.TimeSeriesData
 	// check the non changing items
@@ -186,7 +188,8 @@ func TestTimeSeriesDescriptionListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.TimeSeriesDescriptionData
 	// check the non changing items
@@ -224,7 +227,8 @@ func TestTimeSeriesConstraintsListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.TimeSeriesConstraintsData
 	// check the non changing items

--- a/model/timetable_additions.go
+++ b/model/timetable_additions.go
@@ -4,37 +4,55 @@ package model
 
 var _ Updater = (*TimeTableListDataType)(nil)
 
-func (r *TimeTableListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *TimeTableListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []TimeTableDataType
 	if newList != nil {
 		newData = newList.(*TimeTableListDataType).TimeTableData
 	}
 
-	r.TimeTableData = UpdateList(remoteWrite, r.TimeTableData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.TimeTableData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.TimeTableData = data
+	}
+
+	return success
 }
 
 // TimeTableConstraintsListDataType
 
 var _ Updater = (*TimeTableConstraintsListDataType)(nil)
 
-func (r *TimeTableConstraintsListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *TimeTableConstraintsListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []TimeTableConstraintsDataType
 	if newList != nil {
 		newData = newList.(*TimeTableConstraintsListDataType).TimeTableConstraintsData
 	}
 
-	r.TimeTableConstraintsData = UpdateList(remoteWrite, r.TimeTableConstraintsData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.TimeTableConstraintsData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.TimeTableConstraintsData = data
+	}
+
+	return success
 }
 
 // TimeTableDescriptionListDataType
 
 var _ Updater = (*TimeTableDescriptionListDataType)(nil)
 
-func (r *TimeTableDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *TimeTableDescriptionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []TimeTableDescriptionDataType
 	if newList != nil {
 		newData = newList.(*TimeTableDescriptionListDataType).TimeTableDescriptionData
 	}
 
-	r.TimeTableDescriptionData = UpdateList(remoteWrite, r.TimeTableDescriptionData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.TimeTableDescriptionData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.TimeTableDescriptionData = data
+	}
+
+	return success
 }

--- a/model/timetable_additions_test.go
+++ b/model/timetable_additions_test.go
@@ -37,7 +37,8 @@ func TestTimeTableListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.TimeTableData
 	// check the non changing items
@@ -75,7 +76,8 @@ func TestTimeTableConstraintsListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.TimeTableConstraintsData
 	// check the non changing items
@@ -113,7 +115,8 @@ func TestTimeTableDescriptionListDataType_Update(t *testing.T) {
 	}
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(t, success)
 
 	data := sut.TimeTableDescriptionData
 	// check the non changing items

--- a/model/update.go
+++ b/model/update.go
@@ -20,17 +20,28 @@ type Updater interface {
 //   - the new data set
 //   - true if everything was successful, false if not
 func UpdateList[T any](remoteWrite bool, existingData []T, newData []T, filterPartial, filterDelete *FilterType) ([]T, bool) {
+	success := true
+
 	// process delete filter (with selectors and elements)
 	if filterDelete != nil {
 		if filterData, err := filterDelete.Data(); err == nil {
-			existingData = deleteFilteredData(existingData, filterData)
+			updatedData, noErrors := deleteFilteredData(remoteWrite, existingData, filterData)
+			if noErrors {
+				existingData = updatedData
+			} else {
+				success = false
+			}
 		}
 	}
 
 	// process update filter (with selectors and elements)
 	if filterPartial != nil {
 		if filterData, err := filterPartial.Data(); err == nil {
-			return copyToSelectedData(existingData, filterData, &newData[0]), true
+			newData, noErrors := copyToSelectedData(remoteWrite, existingData, filterData, &newData[0])
+			if !noErrors {
+				success = false
+			}
+			return newData, success
 		}
 	}
 
@@ -40,14 +51,21 @@ func UpdateList[T any](remoteWrite bool, existingData []T, newData []T, filterPa
 	if len(newData) > 0 && !HasIdentifiers(newData[0]) {
 		// no identifiers specified --> copy data to all existing items
 		// (see EEBus_SPINE_TS_ProtocolSpecification.pdf, Table 7: Considered cmdOptions combinations for classifier "notify")
-		return copyToAllData(existingData, &newData[0]), true
+		newData, noErrors := copyToAllData(remoteWrite, existingData, &newData[0])
+		if !noErrors {
+			success = false
+		}
+		return newData, success
 	}
 
 	result, noErrors := Merge(remoteWrite, existingData, newData)
+	if !noErrors {
+		success = false
+	}
 
 	result = SortData(result)
 
-	return result, noErrors
+	return result, success
 }
 
 // return a list of field names that have the eebus tag
@@ -150,34 +168,86 @@ func SortData[T any](data []T) []T {
 	return data
 }
 
-func copyToSelectedData[T any](existingData []T, filterData *FilterData, newData *T) []T {
+// Copy data t elements matching the selected items
+//
+// Parameter remoteWrite defines if this data came on from a remote service, as that is then to
+// ignore the "writecheck" tagges fields and should only be allowed to write if the "writecheck" tagged field
+// boolean is set to true
+//
+// returns:
+//   - the new data set
+//   - true if everything was successful, false if not
+func copyToSelectedData[T any](remoteWrite bool, existingData []T, filterData *FilterData, newData *T) ([]T, bool) {
 	if filterData.Selector == nil {
-		return existingData
+		return existingData, true
 	}
+
+	success := true
 
 	for i := range existingData {
 		if filterData.SelectorMatch(util.Ptr(existingData[i])) {
+			writeAllowed := writeAllowed(existingData[i])
+			if !writeAllowed && remoteWrite {
+				success = false
+				continue
+			}
+
 			CopyNonNilDataFromItemToItem(newData, &existingData[i])
 			break
 		}
 	}
-	return existingData
+	return existingData, success
 }
 
-func copyToAllData[T any](existingData []T, newData *T) []T {
+// Copy data to all elements
+//
+// Parameter remoteWrite defines if this data came on from a remote service, as that is then to
+// ignore the "writecheck" tagges fields and should only be allowed to write if the "writecheck" tagged field
+// boolean is set to true
+//
+// returns:
+//   - the new data set
+//   - true if everything was successful, false if not
+func copyToAllData[T any](remoteWrite bool, existingData []T, newData *T) ([]T, bool) {
+	success := true
+
 	for i := range existingData {
+		writeAllowed := writeAllowed(existingData[i])
+		if !writeAllowed && remoteWrite {
+			success = false
+			continue
+		}
+
 		CopyNonNilDataFromItemToItem(newData, &existingData[i])
 	}
-	return existingData
+
+	return existingData, success
 }
 
-func deleteFilteredData[T any](existingData []T, filterData *FilterData) []T {
+// Execute a partial delete filter
+//
+// Parameter remoteWrite defines if this data came on from a remote service, as that is then to
+// ignore the "writecheck" tagges fields and should only be allowed to write if the "writecheck" tagged field
+// boolean is set to true
+//
+// returns:
+//   - the new data set
+//   - true if everything was successful, false if not
+func deleteFilteredData[T any](remoteWrite bool, existingData []T, filterData *FilterData) ([]T, bool) {
+	success := true
+
 	if filterData.Elements == nil && filterData.Selector == nil {
-		return existingData
+		return existingData, true
 	}
 
 	result := []T{}
 	for i := range existingData {
+		writeAllowed := writeAllowed(existingData[i])
+		if !writeAllowed && remoteWrite {
+			success = false
+			continue
+		}
+
 		if filterData.Selector != nil && filterData.Elements != nil {
 			// selector and elements filter
 
@@ -203,7 +273,8 @@ func deleteFilteredData[T any](existingData []T, filterData *FilterData) []T {
 			result = append(result, existingData[i])
 		}
 	}
-	return result
+
+	return result, success
 }
 
 func isFieldValueNil(field interface{}) bool {

--- a/model/update_test.go
+++ b/model/update_test.go
@@ -24,8 +24,9 @@ func TestUpdateList_NewItem(t *testing.T) {
 	expectedResult := []TestUpdateData{{Id: util.Ptr(uint(1)), DataItem: util.Ptr(int(1))}, {Id: util.Ptr(uint(2)), DataItem: util.Ptr(int(2))}}
 
 	// Act
-	result := UpdateList(false, existingData, newData, nil, nil)
+	result, boolV := UpdateList(false, existingData, newData, nil, nil)
 
+	assert.True(t, boolV)
 	assert.Equal(t, expectedResult, result)
 }
 
@@ -36,8 +37,9 @@ func TestUpdateList_ChangedItem(t *testing.T) {
 	expectedResult := []TestUpdateData{{Id: util.Ptr(uint(1)), DataItem: util.Ptr(int(2))}}
 
 	// Act
-	result := UpdateList(false, existingData, newData, nil, nil)
+	result, boolV := UpdateList(false, existingData, newData, nil, nil)
 
+	assert.True(t, boolV)
 	assert.Equal(t, expectedResult, result)
 }
 
@@ -48,8 +50,9 @@ func TestUpdateList_NewAndChangedItem(t *testing.T) {
 	expectedResult := []TestUpdateData{{Id: util.Ptr(uint(1)), DataItem: util.Ptr(int(2))}, {Id: util.Ptr(uint(3)), DataItem: util.Ptr(int(3))}}
 
 	// Act
-	result := UpdateList(false, existingData, newData, nil, nil)
+	result, boolV := UpdateList(false, existingData, newData, nil, nil)
 
+	assert.True(t, boolV)
 	assert.Equal(t, expectedResult, result)
 }
 
@@ -60,8 +63,9 @@ func TestUpdateList_ItemWithNoIdentifier(t *testing.T) {
 	expectedResult := []TestUpdateData{{Id: util.Ptr(uint(1)), DataItem: util.Ptr(int(3))}, {Id: util.Ptr(uint(2)), DataItem: util.Ptr(int(3))}}
 
 	// Act
-	result := UpdateList(false, existingData, newData, nil, nil)
+	result, boolV := UpdateList(false, existingData, newData, nil, nil)
 
+	assert.True(t, boolV)
 	assert.Equal(t, expectedResult, result)
 }
 

--- a/model/usecaseinformation_additions_test.go
+++ b/model/usecaseinformation_additions_test.go
@@ -16,11 +16,6 @@ type UseCaseInformationDataTypeSuite struct {
 	suite.Suite
 }
 
-func (s *UseCaseInformationDataTypeSuite) SetupSuite()   {}
-func (s *UseCaseInformationDataTypeSuite) TearDownTest() {}
-
-func (s *UseCaseInformationDataTypeSuite) BeforeTest(suiteName, testName string) {}
-
 func (s *UseCaseInformationDataTypeSuite) Test_AdditionsAndRemovals() {
 	ucs := &UseCaseInformationDataType{}
 	assert.NotNil(s.T(), ucs)

--- a/model/usecaseinformation_additions_test.go_temp
+++ b/model/usecaseinformation_additions_test.go_temp
@@ -16,11 +16,6 @@ type UsecaseInformationSuite struct {
 	suite.Suite
 }
 
-func (s *UsecaseInformationSuite) SetupSuite()   {}
-func (s *UsecaseInformationSuite) TearDownTest() {}
-
-func (s *UsecaseInformationSuite) BeforeTest(suiteName, testName string) {}
-
 func (s *UsecaseInformationSuite) Test_UpdateList() {
 	sut := UseCaseInformationListDataType{
 		UseCaseInformationData: []UseCaseInformationDataType{

--- a/model/version_additions.go
+++ b/model/version_additions.go
@@ -4,11 +4,17 @@ package model
 
 var _ Updater = (*SpecificationVersionListDataType)(nil)
 
-func (r *SpecificationVersionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) {
+func (r *SpecificationVersionListDataType) UpdateList(remoteWrite bool, newList any, filterPartial, filterDelete *FilterType) bool {
 	var newData []SpecificationVersionDataType
 	if newList != nil {
 		newData = newList.(*SpecificationVersionListDataType).SpecificationVersionData
 	}
 
-	r.SpecificationVersionData = UpdateList(remoteWrite, r.SpecificationVersionData, newData, filterPartial, filterDelete)
+	data, success := UpdateList(remoteWrite, r.SpecificationVersionData, newData, filterPartial, filterDelete)
+
+	if success {
+		r.SpecificationVersionData = data
+	}
+
+	return success
 }

--- a/model/version_additions_test.go
+++ b/model/version_additions_test.go
@@ -15,11 +15,6 @@ type VersionSuite struct {
 	suite.Suite
 }
 
-func (s *VersionSuite) SetupSuite()   {}
-func (s *VersionSuite) TearDownTest() {}
-
-func (s *VersionSuite) BeforeTest(suiteName, testName string) {}
-
 func (s *VersionSuite) Test_UpdateList() {
 	sut := SpecificationVersionListDataType{
 		SpecificationVersionData: []SpecificationVersionDataType{
@@ -39,7 +34,8 @@ func (s *VersionSuite) Test_UpdateList() {
 	assert.Equal(s.T(), "1.0.0", string(item1))
 
 	// Act
-	sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	success := sut.UpdateList(false, &newData, NewFilterTypePartial(), nil)
+	assert.True(s.T(), success)
 
 	data = sut.SpecificationVersionData
 	// check properties of updated item

--- a/spine/device_local_test.go
+++ b/spine/device_local_test.go
@@ -336,8 +336,7 @@ func (d *DeviceLocalTestSuite) Test_ProcessCmd() {
 				Entity:  []model.AddressEntityType{1},
 				Feature: util.Ptr(model.AddressFeatureType(3)),
 			},
-			MsgCounter:    util.Ptr(model.MsgCounterType(1)),
-			CmdClassifier: util.Ptr(model.CmdClassifierTypeWrite),
+			MsgCounter: util.Ptr(model.MsgCounterType(1)),
 		},
 		Payload: model.PayloadType{
 			Cmd: []model.CmdType{
@@ -345,6 +344,11 @@ func (d *DeviceLocalTestSuite) Test_ProcessCmd() {
 			},
 		},
 	}
+
+	err = sut.ProcessCmd(datagram, remote)
+	assert.NotNil(d.T(), err)
+
+	datagram.Header.CmdClassifier = util.Ptr(model.CmdClassifierTypeWrite)
 
 	err = sut.ProcessCmd(datagram, remote)
 	assert.NotNil(d.T(), err)

--- a/spine/function_data.go
+++ b/spine/function_data.go
@@ -68,7 +68,9 @@ func (r *FunctionData[T]) UpdateData(remoteWrite bool, newData *T, filterPartial
 	}
 
 	updater := any(r.data).(model.Updater)
-	updater.UpdateList(remoteWrite, newData, filterPartial, filterDelete)
+	if !updater.UpdateList(remoteWrite, newData, filterPartial, filterDelete) {
+		return model.NewErrorTypeFromString("update failed, likely not allowed to write")
+	}
 
 	return nil
 }

--- a/spine/function_data_test.go
+++ b/spine/function_data_test.go
@@ -30,6 +30,14 @@ func TestFunctionData_UpdateData(t *testing.T) {
 	assert.Equal(t, newData.DeviceName, getNewData.DeviceName)
 	assert.NotEqual(t, getData.DeviceName, getNewData.DeviceName)
 	assert.Equal(t, functionType, sut.FunctionType())
+
+	sut.UpdateDataAny(false, newData, nil, nil)
+	getNewDataAny := sut.DataCopyAny()
+	newDataAny := getNewDataAny.(*model.DeviceClassificationManufacturerDataType)
+
+	assert.Equal(t, newData.DeviceName, newDataAny.DeviceName)
+	assert.NotEqual(t, getData.DeviceName, newDataAny.DeviceName)
+	assert.Equal(t, functionType, sut.FunctionType())
 }
 
 func TestFunctionData_UpdateDataPartial(t *testing.T) {

--- a/spine/util_test.go
+++ b/spine/util_test.go
@@ -46,7 +46,9 @@ func (s *UtilsSuite) Test_DataCopyOfType() {
 	data := &model.ElectricalConnectionDescriptionListDataType{
 		ElectricalConnectionDescriptionData: []model.ElectricalConnectionDescriptionDataType{},
 	}
-	localFeature.updateData(false, model.FunctionTypeElectricalConnectionDescriptionListData, data, nil, nil)
+	updatedData, err1 := localFeature.updateData(false, model.FunctionTypeElectricalConnectionDescriptionListData, data, nil, nil)
+	assert.NotNil(s.T(), updatedData)
+	assert.Nil(s.T(), err1)
 
 	_, err = LocalFeatureDataCopyOfType[*model.ElectricalConnectionDescriptionListDataType](
 		localFeature,


### PR DESCRIPTION
If an incoming write message tries to update any data item that is set to be not changeable, this will now cause the complete write not to be executed and result in an error  returned to the remote device

Fixes https://github.com/enbility/spine-go/issues/11
