### PR TITLE
Fix subscription removal for multiple remotes

### DIFF
--- a/spine/helper_test.go
+++ b/spine/helper_test.go
@@ -18,8 +18,9 @@ import (
 )
 
 const (
-	wallbox_detaileddiscoverydata_recv_reply_file_path  = "./testdata/wallbox_detaileddiscoverydata_recv_reply.json"
-	wallbox_detaileddiscoverydata_recv_notify_file_path = "./testdata/wallbox_detaileddiscoverydata_recv_notify.json"
+	wallbox_detaileddiscoverydata_recv_reply_file_path         = "./testdata/wallbox_detaileddiscoverydata_recv_reply.json"
+	wallbox_detaileddiscoverydata_recv_notify_file_path        = "./testdata/wallbox_detaileddiscoverydata_recv_notify.json"
+	wallbox_detaileddiscoverydata_recv_notify_remove_file_path = "./testdata/wallbox_detaileddiscoverydata_recv_notify_remove.json"
 )
 
 type WriteMessageHandler struct {

--- a/spine/nodemanagement_detaileddiscovery_test.go
+++ b/spine/nodemanagement_detaileddiscovery_test.go
@@ -153,6 +153,27 @@ func (s *NodeManagementSuite) TestDetailedDiscovery_RecvNotifyAdded() {
 			assert.Equal(s.T(), 10, len(ev.Features()))
 		}
 	}
+
+	// Act
+	msgCounter, _ = s.remoteDevice.HandleSpineMesssage(loadFileData(s.T(), wallbox_detaileddiscoverydata_recv_notify_remove_file_path))
+	waitForAck(s.T(), msgCounter, s.writeHandler)
+
+	// Assert
+	rEntities = remoteDevice.Entities()
+	if assert.Equal(s.T(), 2, len(rEntities)) {
+		{
+			di := rEntities[DeviceInformationEntityId]
+			assert.NotNil(s.T(), di)
+			assert.Equal(s.T(), model.EntityTypeTypeDeviceInformation, di.EntityType())
+			assert.Equal(s.T(), 2, len(di.Features()))
+		}
+		{
+			evse := rEntities[1]
+			assert.NotNil(s.T(), evse)
+			assert.Equal(s.T(), model.EntityTypeTypeEVSE, evse.EntityType())
+			assert.Equal(s.T(), 3, len(evse.Features()))
+		}
+	}
 }
 
 func (s *NodeManagementSuite) TestDetailedDiscovery_SendReplyWithAcknowledge() {

--- a/spine/subscription_manager.go
+++ b/spine/subscription_manager.go
@@ -114,7 +114,9 @@ func (c *SubscriptionManager) RemoveSubscription(data model.SubscriptionManageme
 	for _, item := range c.subscriptionEntries {
 		itemAddress := item.ClientFeature.Address()
 
-		if !reflect.DeepEqual(*itemAddress, clientAddress) &&
+		if !reflect.DeepEqual(itemAddress.Device, clientAddress.Device) ||
+			!reflect.DeepEqual(itemAddress.Entity, clientAddress.Entity) ||
+			!reflect.DeepEqual(itemAddress.Feature, clientAddress.Feature) ||
 			!reflect.DeepEqual(item.ServerFeature, serverFeature) {
 			newSubscriptionEntries = append(newSubscriptionEntries, item)
 		}
@@ -163,7 +165,8 @@ func (c *SubscriptionManager) RemoveSubscriptionsForEntity(remoteEntity api.Enti
 
 	var newSubscriptionEntries []*api.SubscriptionEntry
 	for _, item := range c.subscriptionEntries {
-		if !reflect.DeepEqual(item.ClientFeature.Address().Entity, remoteEntity.Address().Entity) {
+		if !reflect.DeepEqual(item.ClientFeature.Address().Device, remoteEntity.Address().Device) ||
+			!reflect.DeepEqual(item.ClientFeature.Address().Entity, remoteEntity.Address().Entity) {
 			newSubscriptionEntries = append(newSubscriptionEntries, item)
 			continue
 		}

--- a/spine/subscription_manager_test.go
+++ b/spine/subscription_manager_test.go
@@ -18,9 +18,10 @@ func TestSubscriptionManagerSuite(t *testing.T) {
 type SubscriptionManagerSuite struct {
 	suite.Suite
 
-	localDevice  api.DeviceLocalInterface
-	remoteDevice api.DeviceRemoteInterface
-	sut          api.SubscriptionManagerInterface
+	localDevice api.DeviceLocalInterface
+	remoteDevice,
+	remoteDevice2 api.DeviceRemoteInterface
+	sut api.SubscriptionManagerInterface
 }
 
 func (suite *SubscriptionManagerSuite) WriteShipMessageWithPayload([]byte) {}
@@ -31,8 +32,11 @@ func (suite *SubscriptionManagerSuite) SetupSuite() {
 	ski := "test"
 	sender := NewSender(suite)
 	suite.remoteDevice = NewDeviceRemote(suite.localDevice, ski, sender)
-
 	_ = suite.localDevice.SetupRemoteDevice(ski, suite)
+
+	ski2 := "test2"
+	suite.remoteDevice2 = NewDeviceRemote(suite.localDevice, ski2, sender)
+	_ = suite.localDevice.SetupRemoteDevice(ski2, suite)
 
 	suite.sut = NewSubscriptionManager(suite.localDevice)
 }
@@ -49,9 +53,24 @@ func (suite *SubscriptionManagerSuite) Test_Subscriptions() {
 	remoteFeature := NewFeatureRemote(remoteEntity.NextFeatureId(), remoteEntity, model.FeatureTypeTypeDeviceDiagnosis, model.RoleTypeClient)
 	remoteFeature.Address().Device = util.Ptr(model.AddressDeviceType("remoteDevice"))
 	remoteEntity.AddFeature(remoteFeature)
+	remoteEntity.Address().Device = util.Ptr(model.AddressDeviceType("remoteDevice"))
 
 	subscrRequest := model.SubscriptionManagementRequestCallType{
 		ClientAddress:     remoteFeature.Address(),
+		ServerAddress:     localFeature.Address(),
+		ServerFeatureType: util.Ptr(model.FeatureTypeTypeDeviceDiagnosis),
+	}
+
+	remoteEntity2 := NewEntityRemote(suite.remoteDevice2, model.EntityTypeTypeEVSE, []model.AddressEntityType{1})
+	suite.remoteDevice2.AddEntity(remoteEntity2)
+
+	remoteFeature2 := NewFeatureRemote(remoteEntity2.NextFeatureId(), remoteEntity2, model.FeatureTypeTypeDeviceDiagnosis, model.RoleTypeClient)
+	remoteFeature2.Address().Device = util.Ptr(model.AddressDeviceType("remoteDevice2"))
+	remoteEntity2.AddFeature(remoteFeature2)
+	remoteEntity2.Address().Device = util.Ptr(model.AddressDeviceType("remoteDevice2"))
+
+	subscrRequest2 := model.SubscriptionManagementRequestCallType{
+		ClientAddress:     remoteFeature2.Address(),
 		ServerAddress:     localFeature.Address(),
 		ServerFeatureType: util.Ptr(model.FeatureTypeTypeDeviceDiagnosis),
 	}
@@ -67,6 +86,12 @@ func (suite *SubscriptionManagerSuite) Test_Subscriptions() {
 	assert.NotNil(suite.T(), err)
 
 	subs = subMgr.Subscriptions(suite.remoteDevice)
+	assert.Equal(suite.T(), 1, len(subs))
+
+	err = subMgr.AddSubscription(suite.remoteDevice2, subscrRequest2)
+	assert.Nil(suite.T(), err)
+
+	subs = subMgr.Subscriptions(suite.remoteDevice2)
 	assert.Equal(suite.T(), 1, len(subs))
 
 	subscrDelete := model.SubscriptionManagementDeleteCallType{
@@ -90,8 +115,21 @@ func (suite *SubscriptionManagerSuite) Test_Subscriptions() {
 	subs = subMgr.Subscriptions(suite.remoteDevice)
 	assert.Equal(suite.T(), 1, len(subs))
 
+	subMgr.RemoveSubscriptionsForEntity(nil)
+
+	subs = subMgr.Subscriptions(suite.remoteDevice)
+	assert.Equal(suite.T(), 1, len(subs))
+
+	subMgr.RemoveSubscriptionsForDevice(nil)
+
+	subs = subMgr.Subscriptions(suite.remoteDevice)
+	assert.Equal(suite.T(), 1, len(subs))
+
 	subMgr.RemoveSubscriptionsForDevice(suite.remoteDevice)
 
 	subs = subMgr.Subscriptions(suite.remoteDevice)
 	assert.Equal(suite.T(), 0, len(subs))
+
+	subs = subMgr.Subscriptions(suite.remoteDevice2)
+	assert.Equal(suite.T(), 1, len(subs))
 }

--- a/spine/testdata/wallbox_detaileddiscoverydata_recv_notify_remove.json
+++ b/spine/testdata/wallbox_detaileddiscoverydata_recv_notify_remove.json
@@ -1,0 +1,61 @@
+{
+  "datagram": {
+      "header": {
+          "specificationVersion": "1.3.0",
+          "addressSource": {
+              "device": "Wallbox",
+              "entity": [
+                  0
+              ],
+              "feature": 0
+          },
+          "addressDestination": {
+              "device": "HEMS",
+              "entity": [
+                  0
+              ],
+              "feature": 0
+          },
+          "msgCounter": 4,
+          "cmdClassifier": "notify",
+          "ackRequest":true
+      },
+      "payload": {
+          "cmd": [
+              {
+                  "function": "nodeManagementDetailedDiscoveryData",
+                  "filter": [
+                      {
+                          "cmdControl": {
+                              "partial": {}
+                          }
+                      }
+                  ],
+                  "nodeManagementDetailedDiscoveryData": {
+                      "deviceInformation": {
+                          "description": {
+                              "deviceAddress": {
+                                  "device": "Wallbox"
+                              }
+                          }
+                      },
+                      "entityInformation": [
+                          {
+                              "description": {
+                                  "entityAddress": {
+                                      "entity": [
+                                          1,
+                                          1
+                                      ]
+                                  },
+                                  "entityType": "EV",
+                                  "lastStateChange": "removed"
+                              }
+                          }
+                      ]
+                  }
+              }
+          ]
+      }
+  }
+}


### PR DESCRIPTION
- When a service has multiple similar remote devices (EVSEs with attached EVs), then removing an EV did remove the subscriptions for all remote EVs and therefor these wallboxes switched into fallback mode. This change fixes this
- Add more tests for NodeManagementDetailedDiscovery entity removal