### PR TITLE
Add support for handling duplicate read messages

### DIFF
--- a/spine/feature_local_test.go
+++ b/spine/feature_local_test.go
@@ -48,6 +48,72 @@ func (s *LocalFeatureTestSuite) BeforeTest(suiteName, testName string) {
 	s.remoteSubFeature, _ = createRemoteEntityAndFeature(remoteDevice, 2, s.subFeatureType, s.serverWriteFunction)
 }
 
+func (s *LocalFeatureTestSuite) TestDeviceClassification_Cache() {
+	expMsgCounter1 := model.MsgCounterType(1)
+
+	s.senderMock.EXPECT().Request(
+		model.CmdClassifierTypeRead,
+		s.localFeature.Address(),
+		s.remoteServerFeature.Address(),
+		false,
+		mock.AnythingOfType("[]model.CmdType")).Return(&expMsgCounter1, nil).Once()
+
+	msgCounter, err := s.localFeature.RequestRemoteDataBySenderAddress(model.CmdType{}, s.senderMock, "dummy", s.remoteServerFeature.Address(), 0)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), msgCounter)
+
+	msgCounter2, err := s.localFeature.RequestRemoteDataBySenderAddress(model.CmdType{}, s.senderMock, "dummy", s.remoteServerFeature.Address(), 0)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), msgCounter2)
+	assert.Equal(s.T(), *msgCounter, *msgCounter2)
+
+	replyMsg := api.Message{
+		Cmd: model.CmdType{
+			DeviceClassificationManufacturerData: &model.DeviceClassificationManufacturerDataType{},
+		},
+		CmdClassifier: model.CmdClassifierTypeReply,
+		RequestHeader: &model.HeaderType{
+			MsgCounter:          util.Ptr(model.MsgCounterType(1)),
+			MsgCounterReference: msgCounter,
+		},
+		FeatureRemote: s.remoteFeature,
+	}
+	s.localFeature.HandleMessage(&replyMsg)
+
+	expMsgCounter3 := model.MsgCounterType(3)
+	s.senderMock.EXPECT().Request(
+		model.CmdClassifierTypeRead,
+		s.localFeature.Address(),
+		s.remoteServerFeature.Address(),
+		false,
+		mock.AnythingOfType("[]model.CmdType")).Return(&expMsgCounter3, nil).Once()
+
+	msgCounter3, err := s.localFeature.RequestRemoteDataBySenderAddress(model.CmdType{}, s.senderMock, "dummy", s.remoteServerFeature.Address(), 0)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), msgCounter3)
+	assert.NotEqual(s.T(), *msgCounter, *msgCounter3)
+
+	for i := 0; i < 50; i++ {
+		expMsgCounter4 := model.MsgCounterType(i + 3)
+		remoteAddress := &model.FeatureAddressType{
+			Device:  s.remoteServerFeature.Device().Address(),
+			Entity:  []model.AddressEntityType{1},
+			Feature: util.Ptr(model.AddressFeatureType(i)),
+		}
+		s.senderMock.EXPECT().Request(
+			model.CmdClassifierTypeRead,
+			s.localFeature.Address(),
+			mock.Anything,
+			false,
+			mock.AnythingOfType("[]model.CmdType")).Return(&expMsgCounter4, nil).Once()
+
+		msgCounter4, err := s.localFeature.RequestRemoteDataBySenderAddress(model.CmdType{}, s.senderMock, "dummy", remoteAddress, 0)
+		assert.Nil(s.T(), err)
+		assert.NotNil(s.T(), expMsgCounter4)
+		assert.NotEqual(s.T(), *msgCounter, *msgCounter4)
+	}
+}
+
 func (s *LocalFeatureTestSuite) TestDeviceClassification_Functions() {
 	fcts := s.localServerFeatureWrite.Functions()
 	assert.NotNil(s.T(), fcts)


### PR DESCRIPTION
If different use case implementations trigger the same read messages, currently they are all sent through and result in multiple responses.

This change will cache up to the last 20 read messages for each feature and not resend duplicates to the same remote feature. Instead it will return the message counter of the previous read request, so all requestors will get the same responses.

Fixes https://github.com/enbility/spine-go/issues/27