### PR TITLE
Add support for heartbeats on multiple local entities

### DIFF
--- a/api/device.go
+++ b/api/device.go
@@ -76,9 +76,6 @@ type DeviceLocalInterface interface {
 	// Send a notify message to remote device subscribing to a specific feature
 	NotifySubscribers(featureAddress *model.FeatureAddressType, cmd model.CmdType)
 
-	// Get the hearbeat manager
-	HeartbeatManager() HeartbeatManagerInterface
-
 	// Get the SPINE data structure for NodeManagementDetailDiscoveryData messages for this device
 	Information() *model.NodeManagementDetailedDiscoveryDeviceInformationType
 }

--- a/api/entity.go
+++ b/api/entity.go
@@ -25,6 +25,9 @@ type EntityLocalInterface interface {
 	// Get the associated DeviceLocalInterface implementation
 	Device() DeviceLocalInterface
 
+	// Get the hearbeat manager for this entity
+	HeartbeatManager() HeartbeatManagerInterface
+
 	// Add a new feature with a given FeatureLocalInterface implementation
 	AddFeature(f FeatureLocalInterface)
 	// Get a FeatureLocalInterface implementation for a given feature type and role or create it if it does not exist yet and return it

--- a/integration_tests/helper_test.go
+++ b/integration_tests/helper_test.go
@@ -101,8 +101,8 @@ func beforeTest(
 	fId uint, ftype model.FeatureTypeType,
 	frole model.RoleType) (api.DeviceLocalInterface, string, api.DeviceRemoteInterface, *WriteMessageHandler) {
 	sut := spine.NewDeviceLocal("TestBrandName", "TestDeviceModel", "TestSerialNumber", "TestDeviceCode",
-		"TestDeviceAddress", model.DeviceTypeTypeEnergyManagementSystem, model.NetworkManagementFeatureSetTypeSmart, time.Second*4)
-	localEntity := spine.NewEntityLocal(sut, model.EntityTypeTypeCEM, spine.NewAddressEntityType([]uint{1}))
+		"TestDeviceAddress", model.DeviceTypeTypeEnergyManagementSystem, model.NetworkManagementFeatureSetTypeSmart)
+	localEntity := spine.NewEntityLocal(sut, model.EntityTypeTypeCEM, spine.NewAddressEntityType([]uint{1}), time.Second*4)
 	sut.AddEntity(localEntity)
 	f := spine.NewFeatureLocal(fId, localEntity, ftype, frole)
 	localEntity.AddFeature(f)

--- a/spine/binding_manager_test.go
+++ b/spine/binding_manager_test.go
@@ -27,7 +27,7 @@ type BindingManagerSuite struct {
 
 func (s *BindingManagerSuite) BeforeTest(suiteName, testName string) {
 	s.localDevice = NewDeviceLocal("TestBrandName", "TestDeviceModel", "TestSerialNumber", "TestDeviceCode",
-		"TestDeviceAddress", model.DeviceTypeTypeEnergyManagementSystem, model.NetworkManagementFeatureSetTypeSmart, time.Second*4)
+		"TestDeviceAddress", model.DeviceTypeTypeEnergyManagementSystem, model.NetworkManagementFeatureSetTypeSmart)
 	remoteSki := "TestRemoteSki"
 
 	s.writeHandler = &WriteMessageHandler{}
@@ -40,7 +40,7 @@ func (s *BindingManagerSuite) BeforeTest(suiteName, testName string) {
 }
 
 func (suite *BindingManagerSuite) Test_Bindings() {
-	entity := NewEntityLocal(suite.localDevice, model.EntityTypeTypeCEM, []model.AddressEntityType{1})
+	entity := NewEntityLocal(suite.localDevice, model.EntityTypeTypeCEM, []model.AddressEntityType{1}, time.Second*4)
 	suite.localDevice.AddEntity(entity)
 
 	localFeature := entity.GetOrAddFeature(model.FeatureTypeTypeDeviceDiagnosis, model.RoleTypeServer)

--- a/spine/device_local.go
+++ b/spine/device_local.go
@@ -6,7 +6,6 @@ import (
 	"reflect"
 	"slices"
 	"sync"
-	"time"
 
 	shipapi "github.com/enbility/ship-go/api"
 	"github.com/enbility/ship-go/logging"
@@ -20,7 +19,6 @@ type DeviceLocal struct {
 	entities            []api.EntityLocalInterface
 	subscriptionManager api.SubscriptionManagerInterface
 	bindingManager      api.BindingManagerInterface
-	heartbeatManager    api.HeartbeatManagerInterface
 	nodeManagement      *NodeManagement
 
 	remoteDevices map[string]api.DeviceRemoteInterface
@@ -41,8 +39,7 @@ type DeviceLocal struct {
 func NewDeviceLocal(
 	brandName, deviceModel, serialNumber, deviceCode, deviceAddress string,
 	deviceType model.DeviceTypeType,
-	featureSet model.NetworkManagementFeatureSetType,
-	heartbeatTimeout time.Duration) *DeviceLocal {
+	featureSet model.NetworkManagementFeatureSetType) *DeviceLocal {
 	address := model.AddressDeviceType(deviceAddress)
 
 	var fSet *model.NetworkManagementFeatureSetType
@@ -61,7 +58,6 @@ func NewDeviceLocal(
 
 	res.subscriptionManager = NewSubscriptionManager(res)
 	res.bindingManager = NewBindingManager(res)
-	res.heartbeatManager = NewHeartbeatManager(res, res.subscriptionManager, heartbeatTimeout)
 
 	res.addDeviceInformation()
 	return res
@@ -420,10 +416,6 @@ func (r *DeviceLocal) BindingManager() api.BindingManagerInterface {
 	return r.bindingManager
 }
 
-func (r *DeviceLocal) HeartbeatManager() api.HeartbeatManagerInterface {
-	return r.heartbeatManager
-}
-
 func (r *DeviceLocal) Information() *model.NodeManagementDetailedDiscoveryDeviceInformationType {
 	res := model.NodeManagementDetailedDiscoveryDeviceInformationType{
 		Description: &model.NetworkManagementDeviceDescriptionDataType{
@@ -475,7 +467,7 @@ func (r *DeviceLocal) notifySubscribersOfEntity(entity api.EntityLocalInterface,
 
 func (r *DeviceLocal) addDeviceInformation() {
 	entityType := model.EntityTypeTypeDeviceInformation
-	entity := NewEntityLocal(r, entityType, []model.AddressEntityType{model.AddressEntityType(DeviceInformationEntityId)})
+	entity := NewEntityLocal(r, entityType, []model.AddressEntityType{model.AddressEntityType(DeviceInformationEntityId)}, 0)
 
 	{
 		r.nodeManagement = NewNodeManagement(entity.NextFeatureId(), entity)

--- a/spine/device_local_test.go
+++ b/spine/device_local_test.go
@@ -28,7 +28,7 @@ func (d *DeviceLocalTestSuite) WriteShipMessageWithPayload(msg []byte) {
 }
 
 func (d *DeviceLocalTestSuite) Test_RemoveRemoteDevice() {
-	sut := NewDeviceLocal("brand", "model", "serial", "code", "address", model.DeviceTypeTypeEnergyManagementSystem, model.NetworkManagementFeatureSetTypeSmart, time.Second*4)
+	sut := NewDeviceLocal("brand", "model", "serial", "code", "address", model.DeviceTypeTypeEnergyManagementSystem, model.NetworkManagementFeatureSetTypeSmart)
 
 	ski := "test"
 	_ = sut.SetupRemoteDevice(ski, d)
@@ -42,8 +42,8 @@ func (d *DeviceLocalTestSuite) Test_RemoveRemoteDevice() {
 }
 
 func (d *DeviceLocalTestSuite) Test_RemoteDevice() {
-	sut := NewDeviceLocal("brand", "model", "serial", "code", "address", model.DeviceTypeTypeEnergyManagementSystem, model.NetworkManagementFeatureSetTypeSmart, time.Second*4)
-	localEntity := NewEntityLocal(sut, model.EntityTypeTypeCEM, NewAddressEntityType([]uint{1}))
+	sut := NewDeviceLocal("brand", "model", "serial", "code", "address", model.DeviceTypeTypeEnergyManagementSystem, model.NetworkManagementFeatureSetTypeSmart)
+	localEntity := NewEntityLocal(sut, model.EntityTypeTypeCEM, NewAddressEntityType([]uint{1}), time.Second*4)
 	sut.AddEntity(localEntity)
 
 	f := NewFeatureLocal(1, localEntity, model.FeatureTypeTypeElectricalConnection, model.RoleTypeClient)
@@ -98,7 +98,7 @@ func (d *DeviceLocalTestSuite) Test_RemoteDevice() {
 	err := sut.SubscriptionManager().AddSubscription(remote, subscription)
 	assert.Nil(d.T(), err)
 
-	newSubEntity := NewEntityLocal(sut, model.EntityTypeTypeEV, NewAddressEntityType([]uint{1, 1}))
+	newSubEntity := NewEntityLocal(sut, model.EntityTypeTypeEV, NewAddressEntityType([]uint{1, 1}), time.Second*4)
 	f = NewFeatureLocal(1, newSubEntity, model.FeatureTypeTypeLoadControl, model.RoleTypeServer)
 	f.AddFunctionType(model.FunctionTypeLoadControlLimitListData, true, true)
 	newSubEntity.AddFeature(f)
@@ -133,8 +133,8 @@ func (d *DeviceLocalTestSuite) Test_RemoteDevice() {
 }
 
 func (d *DeviceLocalTestSuite) Test_ProcessCmd_NotifyError() {
-	sut := NewDeviceLocal("brand", "model", "serial", "code", "address", model.DeviceTypeTypeEnergyManagementSystem, model.NetworkManagementFeatureSetTypeSmart, time.Second*4)
-	localEntity := NewEntityLocal(sut, model.EntityTypeTypeCEM, NewAddressEntityType([]uint{1}))
+	sut := NewDeviceLocal("brand", "model", "serial", "code", "address", model.DeviceTypeTypeEnergyManagementSystem, model.NetworkManagementFeatureSetTypeSmart)
+	localEntity := NewEntityLocal(sut, model.EntityTypeTypeCEM, NewAddressEntityType([]uint{1}), time.Second*4)
 	localFeature := NewFeatureLocal(50, localEntity, model.FeatureTypeTypeSensing, model.RoleTypeClient)
 	localEntity.AddFeature(localFeature)
 	sut.AddEntity(localEntity)
@@ -178,8 +178,8 @@ func (d *DeviceLocalTestSuite) Test_ProcessCmd_NotifyError() {
 }
 
 func (d *DeviceLocalTestSuite) Test_ProcessCmd_Errors() {
-	sut := NewDeviceLocal("brand", "model", "serial", "code", "address", model.DeviceTypeTypeEnergyManagementSystem, model.NetworkManagementFeatureSetTypeSmart, time.Second*4)
-	localEntity := NewEntityLocal(sut, model.EntityTypeTypeCEM, NewAddressEntityType([]uint{1}))
+	sut := NewDeviceLocal("brand", "model", "serial", "code", "address", model.DeviceTypeTypeEnergyManagementSystem, model.NetworkManagementFeatureSetTypeSmart)
+	localEntity := NewEntityLocal(sut, model.EntityTypeTypeCEM, NewAddressEntityType([]uint{1}), time.Second*4)
 	sut.AddEntity(localEntity)
 
 	ski := "test"
@@ -229,8 +229,8 @@ func (d *DeviceLocalTestSuite) Test_ProcessCmd_Errors() {
 }
 
 func (d *DeviceLocalTestSuite) Test_ProcessCmd() {
-	sut := NewDeviceLocal("brand", "model", "serial", "code", "address", model.DeviceTypeTypeEnergyManagementSystem, model.NetworkManagementFeatureSetTypeSmart, time.Second*4)
-	localEntity := NewEntityLocal(sut, model.EntityTypeTypeCEM, NewAddressEntityType([]uint{1}))
+	sut := NewDeviceLocal("brand", "model", "serial", "code", "address", model.DeviceTypeTypeEnergyManagementSystem, model.NetworkManagementFeatureSetTypeSmart)
+	localEntity := NewEntityLocal(sut, model.EntityTypeTypeCEM, NewAddressEntityType([]uint{1}), time.Second*4)
 	sut.AddEntity(localEntity)
 
 	f1 := NewFeatureLocal(1, localEntity, model.FeatureTypeTypeElectricalConnection, model.RoleTypeClient)

--- a/spine/device_remote_test.go
+++ b/spine/device_remote_test.go
@@ -2,7 +2,6 @@ package spine
 
 import (
 	"testing"
-	"time"
 
 	"github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
@@ -32,7 +31,7 @@ func (s *DeviceRemoteSuite) WriteShipMessageWithPayload([]byte) {}
 func (s *DeviceRemoteSuite) SetupSuite() {}
 
 func (s *DeviceRemoteSuite) BeforeTest(suiteName, testName string) {
-	s.localDevice = NewDeviceLocal("brand", "model", "serial", "code", "address", model.DeviceTypeTypeEnergyManagementSystem, model.NetworkManagementFeatureSetTypeSmart, time.Second*4)
+	s.localDevice = NewDeviceLocal("brand", "model", "serial", "code", "address", model.DeviceTypeTypeEnergyManagementSystem, model.NetworkManagementFeatureSetTypeSmart)
 
 	ski := "test"
 	sender := NewSender(s)

--- a/spine/entity_local_test.go
+++ b/spine/entity_local_test.go
@@ -18,8 +18,8 @@ type EntityLocalTestSuite struct {
 }
 
 func (suite *EntityLocalTestSuite) Test_Entity() {
-	device := NewDeviceLocal("brand", "model", "serial", "code", "address", model.DeviceTypeTypeEnergyManagementSystem, model.NetworkManagementFeatureSetTypeSmart, time.Second*4)
-	entity := NewEntityLocal(device, model.EntityTypeTypeCEM, NewAddressEntityType([]uint{1}))
+	device := NewDeviceLocal("brand", "model", "serial", "code", "address", model.DeviceTypeTypeEnergyManagementSystem, model.NetworkManagementFeatureSetTypeSmart)
+	entity := NewEntityLocal(device, model.EntityTypeTypeCEM, NewAddressEntityType([]uint{1}), time.Second*4)
 	device.AddEntity(entity)
 
 	f := NewFeatureLocal(1, entity, model.FeatureTypeTypeElectricalConnection, model.RoleTypeClient)

--- a/spine/feature_local.go
+++ b/spine/feature_local.go
@@ -90,7 +90,7 @@ func (r *FeatureLocal) AddFunctionType(function model.FunctionType, read, write 
 		r.ftype == model.FeatureTypeTypeDeviceDiagnosis &&
 		function == model.FunctionTypeDeviceDiagnosisHeartbeatData {
 		// Update HeartbeatManager
-		r.Device().HeartbeatManager().SetLocalFeature(r.Entity(), r)
+		r.Entity().HeartbeatManager().SetLocalFeature(r.Entity(), r)
 	}
 }
 

--- a/spine/heartbeat_manager.go
+++ b/spine/heartbeat_manager.go
@@ -10,7 +10,6 @@ import (
 )
 
 type HeartbeatManager struct {
-	localDevice  api.DeviceLocalInterface
 	localEntity  api.EntityLocalInterface
 	localFeature api.FeatureLocalInterface
 
@@ -18,8 +17,7 @@ type HeartbeatManager struct {
 	stopHeartbeatC chan struct{}
 	stopMux        sync.Mutex
 
-	subscriptionManager api.SubscriptionManagerInterface
-	heartBeatTimeout    *model.DurationType
+	heartBeatTimeout *model.DurationType
 
 	mux sync.Mutex
 }
@@ -27,11 +25,10 @@ type HeartbeatManager struct {
 var _ api.HeartbeatManagerInterface = (*HeartbeatManager)(nil)
 
 // Create a new Heartbeat Manager which handles sending of heartbeats
-func NewHeartbeatManager(localDevice api.DeviceLocalInterface, subscriptionManager api.SubscriptionManagerInterface, timeout time.Duration) *HeartbeatManager {
+func NewHeartbeatManager(localEntity api.EntityLocalInterface, timeout time.Duration) *HeartbeatManager {
 	h := &HeartbeatManager{
-		localDevice:         localDevice,
-		subscriptionManager: subscriptionManager,
-		heartBeatTimeout:    model.NewDurationType(timeout),
+		localEntity:      localEntity,
+		heartBeatTimeout: model.NewDurationType(timeout),
 	}
 
 	return h

--- a/spine/helper_test.go
+++ b/spine/helper_test.go
@@ -173,10 +173,10 @@ func waitForAck(t *testing.T, msgCounterReference *model.MsgCounterType, writeHa
 }
 
 func createLocalDeviceAndEntity(entityId uint) (*DeviceLocal, *EntityLocal) {
-	localDevice := NewDeviceLocal("Vendor", "DeviceName", "SerialNumber", "DeviceCode", "Address", model.DeviceTypeTypeEnergyManagementSystem, model.NetworkManagementFeatureSetTypeSmart, time.Second*4)
+	localDevice := NewDeviceLocal("Vendor", "DeviceName", "SerialNumber", "DeviceCode", "Address", model.DeviceTypeTypeEnergyManagementSystem, model.NetworkManagementFeatureSetTypeSmart)
 	localDevice.address = util.Ptr(model.AddressDeviceType("Address"))
 
-	localEntity := NewEntityLocal(localDevice, model.EntityTypeTypeEVSE, []model.AddressEntityType{model.AddressEntityType(entityId)})
+	localEntity := NewEntityLocal(localDevice, model.EntityTypeTypeEVSE, []model.AddressEntityType{model.AddressEntityType(entityId)}, time.Second*4)
 	localDevice.AddEntity(localEntity)
 
 	return localDevice, localEntity

--- a/spine/nodemanagement_detaileddiscovery_test.go
+++ b/spine/nodemanagement_detaileddiscovery_test.go
@@ -2,7 +2,6 @@ package spine
 
 import (
 	"testing"
-	"time"
 
 	"github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
@@ -37,7 +36,7 @@ type NodeManagementSuite struct {
 
 func (s *NodeManagementSuite) BeforeTest(suiteName, testName string) {
 	s.sut = NewDeviceLocal("TestBrandName", "TestDeviceModel", "TestSerialNumber", "TestDeviceCode",
-		"TestDeviceAddress", model.DeviceTypeTypeEnergyManagementSystem, model.NetworkManagementFeatureSetTypeSmart, time.Second*4)
+		"TestDeviceAddress", model.DeviceTypeTypeEnergyManagementSystem, model.NetworkManagementFeatureSetTypeSmart)
 	s.remoteSki = "TestRemoteSki"
 
 	s.writeHandler = &WriteMessageHandler{}

--- a/spine/subscription_manager_test.go
+++ b/spine/subscription_manager_test.go
@@ -27,7 +27,7 @@ type SubscriptionManagerSuite struct {
 func (suite *SubscriptionManagerSuite) WriteShipMessageWithPayload([]byte) {}
 
 func (suite *SubscriptionManagerSuite) SetupSuite() {
-	suite.localDevice = NewDeviceLocal("brand", "model", "serial", "code", "address", model.DeviceTypeTypeEnergyManagementSystem, model.NetworkManagementFeatureSetTypeSmart, time.Second*4)
+	suite.localDevice = NewDeviceLocal("brand", "model", "serial", "code", "address", model.DeviceTypeTypeEnergyManagementSystem, model.NetworkManagementFeatureSetTypeSmart)
 
 	ski := "test"
 	sender := NewSender(suite)
@@ -42,7 +42,7 @@ func (suite *SubscriptionManagerSuite) SetupSuite() {
 }
 
 func (suite *SubscriptionManagerSuite) Test_Subscriptions() {
-	entity := NewEntityLocal(suite.localDevice, model.EntityTypeTypeCEM, []model.AddressEntityType{1})
+	entity := NewEntityLocal(suite.localDevice, model.EntityTypeTypeCEM, []model.AddressEntityType{1}, time.Second*4)
 	suite.localDevice.AddEntity(entity)
 
 	localFeature := entity.GetOrAddFeature(model.FeatureTypeTypeDeviceDiagnosis, model.RoleTypeServer)

--- a/spine/util_test.go
+++ b/spine/util_test.go
@@ -24,8 +24,8 @@ type UtilsSuite struct {
 func (s *UtilsSuite) WriteShipMessageWithPayload([]byte) {}
 
 func (s *UtilsSuite) Test_DataCopyOfType() {
-	s.localDevice = NewDeviceLocal("brand", "model", "serial", "code", "address", model.DeviceTypeTypeEnergyManagementSystem, model.NetworkManagementFeatureSetTypeSmart, time.Second*4)
-	localEntity := NewEntityLocal(s.localDevice, model.EntityTypeTypeCEM, NewAddressEntityType([]uint{1}))
+	s.localDevice = NewDeviceLocal("brand", "model", "serial", "code", "address", model.DeviceTypeTypeEnergyManagementSystem, model.NetworkManagementFeatureSetTypeSmart)
+	localEntity := NewEntityLocal(s.localDevice, model.EntityTypeTypeCEM, NewAddressEntityType([]uint{1}), time.Second*4)
 	s.localDevice.AddEntity(localEntity)
 
 	localFeature := NewFeatureLocal(1, localEntity, model.FeatureTypeTypeElectricalConnection, model.RoleTypeServer)


### PR DESCRIPTION
- Refactor to move the heartbeatmanager from the device to local entity
- timeout 0s will not create a heartbeat manager for the entity, e.g. used by NodeMgmt local entity

Fixes https://github.com/enbility/spine-go/issues/31