### PR TITLE
Fix: Correct Data Types for Setpoint Description, Selector, and HVAC

### DIFF
--- a/model/hvac.go
+++ b/model/hvac.go
@@ -95,7 +95,7 @@ type HvacSystemFunctionOperationModeRelationListDataSelectorsType struct {
 type HvacSystemFunctionSetpointRelationDataType struct {
 	SystemFunctionId *HvacSystemFunctionIdType `json:"systemFunctionId,omitempty" eebus:"key"`
 	OperationModeId  *HvacOperationModeIdType  `json:"operationModeId,omitempty"`
-	SetpointId       *SetpointIdType           `json:"setpointId,omitempty"`
+	SetpointId       []SetpointIdType          `json:"setpointId,omitempty"`
 }
 
 type HvacSystemFunctionSetpointRelationDataElementsType struct {

--- a/model/setpoint.go
+++ b/model/setpoint.go
@@ -65,8 +65,8 @@ type SetpointConstraintsListDataSelectorsType struct {
 
 type SetpointDescriptionDataType struct {
 	SetpointId    *SetpointIdType        `json:"setpointId,omitempty" eebus:"key"`
-	MeasurementId *SetpointIdType        `json:"measurementId,omitempty"`
-	TimeTableId   *SetpointIdType        `json:"timeTableId,omitempty"`
+	MeasurementId *SetpointIdType        `json:"measurementId,omitempty" eebus:"key"`
+	TimeTableId   *SetpointIdType        `json:"timeTableId,omitempty" eebus:"key"`
 	SetpointType  *SetpointTypeType      `json:"setpointType,omitempty"`
 	Unit          *UnitOfMeasurementType `json:"unit,omitempty"`
 	ScopeType     *ScopeTypeType         `json:"scopeType,omitempty"`

--- a/model/setpoint.go
+++ b/model/setpoint.go
@@ -64,14 +64,14 @@ type SetpointConstraintsListDataSelectorsType struct {
 }
 
 type SetpointDescriptionDataType struct {
-	SetpointId    *SetpointIdType   `json:"setpointId,omitempty" eebus:"key"`
-	MeasurementId *SetpointIdType   `json:"measurementId,omitempty"`
-	TimeTableId   *SetpointIdType   `json:"timeTableId,omitempty"`
-	SetpointType  *SetpointTypeType `json:"setpointType,omitempty"`
-	Unit          *ScaledNumberType `json:"unit,omitempty"`
-	ScopeType     *ScaledNumberType `json:"scopeType,omitempty"`
-	Label         *LabelType        `json:"label,omitempty"`
-	Description   *DescriptionType  `json:"description,omitempty"`
+	SetpointId    *SetpointIdType        `json:"setpointId,omitempty" eebus:"key"`
+	MeasurementId *SetpointIdType        `json:"measurementId,omitempty"`
+	TimeTableId   *SetpointIdType        `json:"timeTableId,omitempty"`
+	SetpointType  *SetpointTypeType      `json:"setpointType,omitempty"`
+	Unit          *UnitOfMeasurementType `json:"unit,omitempty"`
+	ScopeType     *ScopeTypeType         `json:"scopeType,omitempty"`
+	Label         *LabelType             `json:"label,omitempty"`
+	Description   *DescriptionType       `json:"description,omitempty"`
 }
 
 type SetpointDescriptionDataElementsType struct {
@@ -90,9 +90,9 @@ type SetpointDescriptionListDataType struct {
 }
 
 type SetpointDescriptionListDataSelectorsType struct {
-	SetpointId    *SetpointIdType   `json:"setpointId,omitempty"`
-	MeasurementId *SetpointIdType   `json:"measurementId,omitempty"`
-	TimeTableId   *SetpointIdType   `json:"timeTableId,omitempty"`
-	SetpointType  *SetpointIdType   `json:"setpointType,omitempty"`
-	ScopeType     *ScaledNumberType `json:"scopeType,omitempty"`
+	SetpointId    *SetpointIdType    `json:"setpointId,omitempty"`
+	MeasurementId *MeasurementIdType `json:"measurementId,omitempty"`
+	TimeTableId   *TimeTableIdType   `json:"timeTableId,omitempty"`
+	SetpointType  *SetpointTypeType  `json:"setpointType,omitempty"`
+	ScopeType     *ScopeTypeType     `json:"scopeType,omitempty"`
 }

--- a/model/setpoint_additions_test.go
+++ b/model/setpoint_additions_test.go
@@ -50,12 +50,16 @@ func TestSetpointDescriptionListDataType_Update(t *testing.T) {
 	sut := SetpointDescriptionListDataType{
 		SetpointDescriptionData: []SetpointDescriptionDataType{
 			{
-				SetpointId:  util.Ptr(SetpointIdType(0)),
-				Description: util.Ptr(DescriptionType("old")),
+				SetpointId:    util.Ptr(SetpointIdType(0)),
+				MeasurementId: util.Ptr(SetpointIdType(0)),
+				TimeTableId:   util.Ptr(SetpointIdType(0)),
+				Description:   util.Ptr(DescriptionType("old")),
 			},
 			{
-				SetpointId:  util.Ptr(SetpointIdType(1)),
-				Description: util.Ptr(DescriptionType("old")),
+				SetpointId:    util.Ptr(SetpointIdType(1)),
+				MeasurementId: util.Ptr(SetpointIdType(1)),
+				TimeTableId:   util.Ptr(SetpointIdType(1)),
+				Description:   util.Ptr(DescriptionType("old")),
 			},
 		},
 	}
@@ -63,8 +67,10 @@ func TestSetpointDescriptionListDataType_Update(t *testing.T) {
 	newData := SetpointDescriptionListDataType{
 		SetpointDescriptionData: []SetpointDescriptionDataType{
 			{
-				SetpointId:  util.Ptr(SetpointIdType(1)),
-				Description: util.Ptr(DescriptionType("new")),
+				SetpointId:    util.Ptr(SetpointIdType(1)),
+				MeasurementId: util.Ptr(SetpointIdType(1)),
+				TimeTableId:   util.Ptr(SetpointIdType(1)),
+				Description:   util.Ptr(DescriptionType("new")),
 			},
 		},
 	}

--- a/spine/function_data_factory.go
+++ b/spine/function_data_factory.go
@@ -102,10 +102,10 @@ func CreateFunctionData[F any](featureType model.FeatureTypeType) []F {
 
 	if featureType == model.FeatureTypeTypeHvac || featureType == model.FeatureTypeTypeGeneric {
 		result = append(result, []F{
-			createFunctionData[model.HvacOperationModeDescriptionDataType, F](model.FunctionTypeHvacOperationModeDescriptionListData),
+			createFunctionData[model.HvacOperationModeDescriptionListDataType, F](model.FunctionTypeHvacOperationModeDescriptionListData),
 			createFunctionData[model.HvacOverrunDescriptionListDataType, F](model.FunctionTypeHvacOverrunDescriptionListData),
 			createFunctionData[model.HvacOverrunListDataType, F](model.FunctionTypeHvacOverrunListData),
-			createFunctionData[model.HvacSystemFunctionDescriptionDataType, F](model.FunctionTypeHvacSystemFunctionDescriptionListData),
+			createFunctionData[model.HvacSystemFunctionDescriptionListDataType, F](model.FunctionTypeHvacSystemFunctionDescriptionListData),
 			createFunctionData[model.HvacSystemFunctionListDataType, F](model.FunctionTypeHvacSystemFunctionListData),
 			createFunctionData[model.HvacSystemFunctionOperationModeRelationListDataType, F](model.FunctionTypeHvacSystemFunctionOperationModeRelationListData),
 			createFunctionData[model.HvacSystemFunctionPowerSequenceRelationListDataType, F](model.FunctionTypeHvacSystemFunctionPowerSequenceRelationListData),

--- a/spine/function_data_factory_test.go
+++ b/spine/function_data_factory_test.go
@@ -39,10 +39,10 @@ func TestFunctionDataFactory_FunctionData(t *testing.T) {
 
 	result = CreateFunctionData[api.FunctionDataInterface](model.FeatureTypeTypeHvac)
 	assert.Equal(t, 8, len(result))
-	assert.IsType(t, &FunctionData[model.HvacOperationModeDescriptionDataType]{}, result[0])
+	assert.IsType(t, &FunctionData[model.HvacOperationModeDescriptionListDataType]{}, result[0])
 	assert.IsType(t, &FunctionData[model.HvacOverrunDescriptionListDataType]{}, result[1])
 	assert.IsType(t, &FunctionData[model.HvacOverrunListDataType]{}, result[2])
-	assert.IsType(t, &FunctionData[model.HvacSystemFunctionDescriptionDataType]{}, result[3])
+	assert.IsType(t, &FunctionData[model.HvacSystemFunctionDescriptionListDataType]{}, result[3])
 	assert.IsType(t, &FunctionData[model.HvacSystemFunctionListDataType]{}, result[4])
 
 	result = CreateFunctionData[api.FunctionDataInterface](model.FeatureTypeTypeIdentification)


### PR DESCRIPTION
This commit addresses the data type issues in the `Setpoint` and `HVAC` model messages, specifically for `SetpointDescriptionDataType`, `SetpointDescriptionListDataSelectorsType`, and `HvacSystemFunctionSetpointRelationDataType`. It also corrects invalid types in `function_data_factory.go` for `FunctionTypeHvacOperationModeDescriptionListData` and `FunctionTypeHvacSystemFunctionDescriptionListData`.

Changes include:
1. Updating `SetpointId` in `hvacSystemFunctionSetpointRelationListData` to be a list, as specified in the EEBus SPINE Technical Specification Resource Specification.
2. Correcting data types for fields in `SetpointDescriptionDataType` and `SetpointDescriptionListDataSelectorsType` also according to the Resource Specification.

Before this commit, sending `FunctionTypeHvacOperationModeDescriptionListData` and `FunctionTypeHvacSystemFunctionOperationModeRelationListData` failed due to invalid data types provided to `createFunctionData` in the factory.

Additionally, the `SetpointId` field needed to be a list, not a single value.  According to the specification, an operation mode can have multiple setpoints (up to four), such as for the "auto" operation mode.

Sending `FunctionTypeSetpointDescriptionListData` also failed due to incorrect field data types.

With these fixes, requests for `FunctionTypeSetpointDescriptionListData`, `FunctionTypeHvacOperationModeDescriptionListData`, and `FunctionTypeHvacSystemFunctionOperationModeRelationListData` now work correctly.

## Screen shots from the EEBus SPINE Technical Specification Resource Specification for quick reference
### 4.3.12.6 hvacSystemFunctionSetpointRelationListData
![image](https://github.com/user-attachments/assets/667d6c72-e4b4-45a1-a4a2-b4d3292f8734)

### 4.3.23.6 setpointDescriptionListData (for `SetpointDescriptionDataType`)
![image](https://github.com/user-attachments/assets/abe9aa6b-2eda-4e82-b023-94c73582ce0e)

### 5.3.21.4.3 Available selectors (for `SetpointDescriptionListDataSelectorsType`)
![image](https://github.com/user-attachments/assets/d1de75c0-48e2-4536-8db2-09e217877816)