### PR TITLE
Fix: Data Types in HVAC System Functions

### DIFF
--- a/model/hvac.go
+++ b/model/hvac.go
@@ -71,12 +71,12 @@ type HvacSystemFunctionListDataType struct {
 }
 
 type HvacSystemFunctionListDataSelectorsType struct {
-	SystemFunctionId []HvacSystemFunctionIdType `json:"systemFunctionId,omitempty"`
+	SystemFunctionId *HvacSystemFunctionIdType `json:"systemFunctionId,omitempty"`
 }
 
 type HvacSystemFunctionOperationModeRelationDataType struct {
 	SystemFunctionId *HvacSystemFunctionIdType `json:"systemFunctionId,omitempty" eebus:"key"`
-	OperationModeId  *HvacOperationModeIdType  `json:"operationModeId,omitempty"`
+	OperationModeId  []HvacOperationModeIdType `json:"operationModeId,omitempty"`
 }
 
 type HvacSystemFunctionOperationModeRelationDataElementsType struct {

--- a/model/hvac_additions_test.go
+++ b/model/hvac_additions_test.go
@@ -51,11 +51,11 @@ func TestHvacSystemFunctionOperationModeRelationListDataType_Update(t *testing.T
 		HvacSystemFunctionOperationModeRelationData: []HvacSystemFunctionOperationModeRelationDataType{
 			{
 				SystemFunctionId: util.Ptr(HvacSystemFunctionIdType(0)),
-				OperationModeId:  util.Ptr(HvacOperationModeIdType(0)),
+				OperationModeId:  []HvacOperationModeIdType{0},
 			},
 			{
 				SystemFunctionId: util.Ptr(HvacSystemFunctionIdType(1)),
-				OperationModeId:  util.Ptr(HvacOperationModeIdType(0)),
+				OperationModeId:  []HvacOperationModeIdType{0},
 			},
 		},
 	}
@@ -64,7 +64,7 @@ func TestHvacSystemFunctionOperationModeRelationListDataType_Update(t *testing.T
 		HvacSystemFunctionOperationModeRelationData: []HvacSystemFunctionOperationModeRelationDataType{
 			{
 				SystemFunctionId: util.Ptr(HvacSystemFunctionIdType(1)),
-				OperationModeId:  util.Ptr(HvacOperationModeIdType(1)),
+				OperationModeId:  []HvacOperationModeIdType{1},
 			},
 		},
 	}
@@ -78,11 +78,11 @@ func TestHvacSystemFunctionOperationModeRelationListDataType_Update(t *testing.T
 	assert.Equal(t, 2, len(data))
 	item1 := data[0]
 	assert.Equal(t, 0, int(*item1.SystemFunctionId))
-	assert.Equal(t, 0, int(*item1.OperationModeId))
+	assert.Equal(t, 0, int(item1.OperationModeId[0]))
 	// check properties of updated item
 	item2 := data[1]
 	assert.Equal(t, 1, int(*item2.SystemFunctionId))
-	assert.Equal(t, 1, int(*item2.OperationModeId))
+	assert.Equal(t, 1, int(item2.OperationModeId[0]))
 }
 
 func TestHvacSystemFunctionSetpointRelationListDataType_Update(t *testing.T) {


### PR DESCRIPTION
This commit fixes the data types of the fields for the following messages:
- `HvacSystemFunctionListDataSelectorsType`
- `HvacSystemFunctionOperationModeRelationDataType`

Before this commit, `HvacSystemFunctionOperationModeRelationDataType`, had a single `operationModeId` for a system function. According to the spec., each system function can have multiple operation modes. Also according to the resource specification, the `OperationModeId` is a list and not a single item.
The selector for `HvacSystemFunctionListDataSelectorsType` was wrong. Instead of a single `SystemFunctionId`, it was a list.

Because of those issues stated above:
1. Sending request for `HvacSystemFunctionOperationModeRelationDataType` failed because the datatype was a single item and not a list.
2. Sending request with a selector for `HvacSystemFunctionListDataType` failed.

Now, both sending a request for `HvacSystemFunctionOperationModeRelationDataType`
and `HvacSystemFunctionListDataType` with a selector success.

### Resource Specification Screen Shots for Quick Reference
#### 4.3.12.5 hvacSystemFunctionOperationModeRelationListData
![image](https://github.com/user-attachments/assets/03cb170d-92c0-4095-8ca6-a94ae22cd05c)

#### 5.3.12.2 hvacSystemFunctionListData
![image](https://github.com/user-attachments/assets/695c206d-82d1-41d8-8cf6-502faec7c882)