### PR TITLE
Update EntityLocalInterface for UseCase handling

### DIFF
--- a/api/entity.go
+++ b/api/entity.go
@@ -49,17 +49,12 @@ type EntityLocalInterface interface {
 		scenarios []model.UseCaseScenarioSupportType,
 	)
 	// Check if a use case is already added
-	HasUseCaseSupport(
-		actor model.UseCaseActorType,
-		useCaseName model.UseCaseNameType) bool
-	// Remove support for a usecase
-	RemoveUseCaseSupport(
-		actor model.UseCaseActorType,
-		useCaseName model.UseCaseNameType,
-	)
+	HasUseCaseSupport(model.UseCaseFilter) bool
+	// Remove one or multiple usecases
+	RemoveUseCaseSupports([]model.UseCaseFilter)
 	// Set the availability of a usecase. This may only be used for usescases
 	// that act as a client within the usecase!
-	SetUseCaseAvailability(actor model.UseCaseActorType, useCaseName model.UseCaseNameType, available bool)
+	SetUseCaseAvailability(filter model.UseCaseFilter, available bool)
 	// Remove all usecases
 	RemoveAllUseCaseSupports()
 

--- a/mocks/EntityLocalInterface.go
+++ b/mocks/EntityLocalInterface.go
@@ -472,17 +472,17 @@ func (_c *EntityLocalInterface_GetOrAddFeature_Call) RunAndReturn(run func(model
 	return _c
 }
 
-// HasUseCaseSupport provides a mock function with given fields: actor, useCaseName
-func (_m *EntityLocalInterface) HasUseCaseSupport(actor model.UseCaseActorType, useCaseName model.UseCaseNameType) bool {
-	ret := _m.Called(actor, useCaseName)
+// HasUseCaseSupport provides a mock function with given fields: _a0
+func (_m *EntityLocalInterface) HasUseCaseSupport(_a0 model.UseCaseFilter) bool {
+	ret := _m.Called(_a0)
 
 	if len(ret) == 0 {
 		panic("no return value specified for HasUseCaseSupport")
 	}
 
 	var r0 bool
-	if rf, ok := ret.Get(0).(func(model.UseCaseActorType, model.UseCaseNameType) bool); ok {
-		r0 = rf(actor, useCaseName)
+	if rf, ok := ret.Get(0).(func(model.UseCaseFilter) bool); ok {
+		r0 = rf(_a0)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
@@ -496,15 +496,14 @@ type EntityLocalInterface_HasUseCaseSupport_Call struct {
 }
 
 // HasUseCaseSupport is a helper method to define mock.On call
-//   - actor model.UseCaseActorType
-//   - useCaseName model.UseCaseNameType
-func (_e *EntityLocalInterface_Expecter) HasUseCaseSupport(actor interface{}, useCaseName interface{}) *EntityLocalInterface_HasUseCaseSupport_Call {
-	return &EntityLocalInterface_HasUseCaseSupport_Call{Call: _e.mock.On("HasUseCaseSupport", actor, useCaseName)}
+//   - _a0 model.UseCaseFilter
+func (_e *EntityLocalInterface_Expecter) HasUseCaseSupport(_a0 interface{}) *EntityLocalInterface_HasUseCaseSupport_Call {
+	return &EntityLocalInterface_HasUseCaseSupport_Call{Call: _e.mock.On("HasUseCaseSupport", _a0)}
 }
 
-func (_c *EntityLocalInterface_HasUseCaseSupport_Call) Run(run func(actor model.UseCaseActorType, useCaseName model.UseCaseNameType)) *EntityLocalInterface_HasUseCaseSupport_Call {
+func (_c *EntityLocalInterface_HasUseCaseSupport_Call) Run(run func(_a0 model.UseCaseFilter)) *EntityLocalInterface_HasUseCaseSupport_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(model.UseCaseActorType), args[1].(model.UseCaseNameType))
+		run(args[0].(model.UseCaseFilter))
 	})
 	return _c
 }
@@ -514,7 +513,7 @@ func (_c *EntityLocalInterface_HasUseCaseSupport_Call) Return(_a0 bool) *EntityL
 	return _c
 }
 
-func (_c *EntityLocalInterface_HasUseCaseSupport_Call) RunAndReturn(run func(model.UseCaseActorType, model.UseCaseNameType) bool) *EntityLocalInterface_HasUseCaseSupport_Call {
+func (_c *EntityLocalInterface_HasUseCaseSupport_Call) RunAndReturn(run func(model.UseCaseFilter) bool) *EntityLocalInterface_HasUseCaseSupport_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -754,36 +753,35 @@ func (_c *EntityLocalInterface_RemoveAllUseCaseSupports_Call) RunAndReturn(run f
 	return _c
 }
 
-// RemoveUseCaseSupport provides a mock function with given fields: actor, useCaseName
-func (_m *EntityLocalInterface) RemoveUseCaseSupport(actor model.UseCaseActorType, useCaseName model.UseCaseNameType) {
-	_m.Called(actor, useCaseName)
+// RemoveUseCaseSupports provides a mock function with given fields: _a0
+func (_m *EntityLocalInterface) RemoveUseCaseSupports(_a0 []model.UseCaseFilter) {
+	_m.Called(_a0)
 }
 
-// EntityLocalInterface_RemoveUseCaseSupport_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RemoveUseCaseSupport'
-type EntityLocalInterface_RemoveUseCaseSupport_Call struct {
+// EntityLocalInterface_RemoveUseCaseSupports_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RemoveUseCaseSupports'
+type EntityLocalInterface_RemoveUseCaseSupports_Call struct {
 	*mock.Call
 }
 
-// RemoveUseCaseSupport is a helper method to define mock.On call
-//   - actor model.UseCaseActorType
-//   - useCaseName model.UseCaseNameType
-func (_e *EntityLocalInterface_Expecter) RemoveUseCaseSupport(actor interface{}, useCaseName interface{}) *EntityLocalInterface_RemoveUseCaseSupport_Call {
-	return &EntityLocalInterface_RemoveUseCaseSupport_Call{Call: _e.mock.On("RemoveUseCaseSupport", actor, useCaseName)}
+// RemoveUseCaseSupports is a helper method to define mock.On call
+//   - _a0 []model.UseCaseFilter
+func (_e *EntityLocalInterface_Expecter) RemoveUseCaseSupports(_a0 interface{}) *EntityLocalInterface_RemoveUseCaseSupports_Call {
+	return &EntityLocalInterface_RemoveUseCaseSupports_Call{Call: _e.mock.On("RemoveUseCaseSupports", _a0)}
 }
 
-func (_c *EntityLocalInterface_RemoveUseCaseSupport_Call) Run(run func(actor model.UseCaseActorType, useCaseName model.UseCaseNameType)) *EntityLocalInterface_RemoveUseCaseSupport_Call {
+func (_c *EntityLocalInterface_RemoveUseCaseSupports_Call) Run(run func(_a0 []model.UseCaseFilter)) *EntityLocalInterface_RemoveUseCaseSupports_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(model.UseCaseActorType), args[1].(model.UseCaseNameType))
+		run(args[0].([]model.UseCaseFilter))
 	})
 	return _c
 }
 
-func (_c *EntityLocalInterface_RemoveUseCaseSupport_Call) Return() *EntityLocalInterface_RemoveUseCaseSupport_Call {
+func (_c *EntityLocalInterface_RemoveUseCaseSupports_Call) Return() *EntityLocalInterface_RemoveUseCaseSupports_Call {
 	_c.Call.Return()
 	return _c
 }
 
-func (_c *EntityLocalInterface_RemoveUseCaseSupport_Call) RunAndReturn(run func(model.UseCaseActorType, model.UseCaseNameType)) *EntityLocalInterface_RemoveUseCaseSupport_Call {
+func (_c *EntityLocalInterface_RemoveUseCaseSupports_Call) RunAndReturn(run func([]model.UseCaseFilter)) *EntityLocalInterface_RemoveUseCaseSupports_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -821,9 +819,9 @@ func (_c *EntityLocalInterface_SetDescription_Call) RunAndReturn(run func(*model
 	return _c
 }
 
-// SetUseCaseAvailability provides a mock function with given fields: actor, useCaseName, available
-func (_m *EntityLocalInterface) SetUseCaseAvailability(actor model.UseCaseActorType, useCaseName model.UseCaseNameType, available bool) {
-	_m.Called(actor, useCaseName, available)
+// SetUseCaseAvailability provides a mock function with given fields: filter, available
+func (_m *EntityLocalInterface) SetUseCaseAvailability(filter model.UseCaseFilter, available bool) {
+	_m.Called(filter, available)
 }
 
 // EntityLocalInterface_SetUseCaseAvailability_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetUseCaseAvailability'
@@ -832,16 +830,15 @@ type EntityLocalInterface_SetUseCaseAvailability_Call struct {
 }
 
 // SetUseCaseAvailability is a helper method to define mock.On call
-//   - actor model.UseCaseActorType
-//   - useCaseName model.UseCaseNameType
+//   - filter model.UseCaseFilter
 //   - available bool
-func (_e *EntityLocalInterface_Expecter) SetUseCaseAvailability(actor interface{}, useCaseName interface{}, available interface{}) *EntityLocalInterface_SetUseCaseAvailability_Call {
-	return &EntityLocalInterface_SetUseCaseAvailability_Call{Call: _e.mock.On("SetUseCaseAvailability", actor, useCaseName, available)}
+func (_e *EntityLocalInterface_Expecter) SetUseCaseAvailability(filter interface{}, available interface{}) *EntityLocalInterface_SetUseCaseAvailability_Call {
+	return &EntityLocalInterface_SetUseCaseAvailability_Call{Call: _e.mock.On("SetUseCaseAvailability", filter, available)}
 }
 
-func (_c *EntityLocalInterface_SetUseCaseAvailability_Call) Run(run func(actor model.UseCaseActorType, useCaseName model.UseCaseNameType, available bool)) *EntityLocalInterface_SetUseCaseAvailability_Call {
+func (_c *EntityLocalInterface_SetUseCaseAvailability_Call) Run(run func(filter model.UseCaseFilter, available bool)) *EntityLocalInterface_SetUseCaseAvailability_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(model.UseCaseActorType), args[1].(model.UseCaseNameType), args[2].(bool))
+		run(args[0].(model.UseCaseFilter), args[1].(bool))
 	})
 	return _c
 }
@@ -851,7 +848,7 @@ func (_c *EntityLocalInterface_SetUseCaseAvailability_Call) Return() *EntityLoca
 	return _c
 }
 
-func (_c *EntityLocalInterface_SetUseCaseAvailability_Call) RunAndReturn(run func(model.UseCaseActorType, model.UseCaseNameType, bool)) *EntityLocalInterface_SetUseCaseAvailability_Call {
+func (_c *EntityLocalInterface_SetUseCaseAvailability_Call) RunAndReturn(run func(model.UseCaseFilter, bool)) *EntityLocalInterface_SetUseCaseAvailability_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/model/nodemanagement_additions.go
+++ b/model/nodemanagement_additions.go
@@ -28,6 +28,12 @@ func (r *NodeManagementDestinationListDataType) UpdateList(remoteWrite, persist 
 	return data, success
 }
 
+// helper type for easier filtering a specific UseCase element
+type UseCaseFilter struct {
+	Actor       UseCaseActorType
+	UseCaseName UseCaseNameType
+}
+
 // NodeManagementUseCaseDataType
 
 // find the matching UseCaseInformation index for
@@ -153,14 +159,13 @@ func (n *NodeManagementUseCaseDataType) SetAvailability(
 // a provided FeatureAddressType, UseCaseActorType and UseCaseNameType
 func (n *NodeManagementUseCaseDataType) RemoveUseCaseSupport(
 	address FeatureAddressType,
-	actor UseCaseActorType,
-	useCaseName UseCaseNameType,
+	filter UseCaseFilter,
 ) {
 	nmMux.Lock()
 	defer nmMux.Unlock()
 
 	// is there an entry for the entity address, actor and usecase name
-	usecaseIndex, ok := n.useCaseInformationIndex(address, actor, useCaseName)
+	usecaseIndex, ok := n.useCaseInformationIndex(address, filter.Actor, filter.UseCaseName)
 	if !ok {
 		return
 	}
@@ -173,7 +178,7 @@ func (n *NodeManagementUseCaseDataType) RemoveUseCaseSupport(
 			continue
 		}
 
-		item.Remove(useCaseName)
+		item.Remove(filter.UseCaseName)
 
 		// only add the item if there are any usecases left
 		if len(item.UseCaseSupport) == 0 {

--- a/model/nodemanagement_additions_test.go
+++ b/model/nodemanagement_additions_test.go
@@ -79,8 +79,10 @@ func (s *NodeManagementUseCaseDataTypeSuite) Test_AdditionsAndRemovals() {
 
 	ucs.RemoveUseCaseSupport(
 		address,
-		UseCaseActorTypeCEM,
-		UseCaseNameTypeEVChargingSummary,
+		UseCaseFilter{
+			Actor:       UseCaseActorTypeCEM,
+			UseCaseName: UseCaseNameTypeEVChargingSummary,
+		},
 	)
 	assert.Equal(s.T(), 2, len(ucs.UseCaseInformation))
 	assert.Equal(s.T(), 2, len(ucs.UseCaseInformation[0].UseCaseSupport))
@@ -95,24 +97,24 @@ func (s *NodeManagementUseCaseDataTypeSuite) Test_AdditionsAndRemovals() {
 
 	ucs.RemoveUseCaseSupport(
 		address,
-		UseCaseActorTypeCEM,
-		UseCaseNameTypeControlOfBattery,
+		UseCaseFilter{
+			Actor:       UseCaseActorTypeCEM,
+			UseCaseName: UseCaseNameTypeControlOfBattery,
+		},
 	)
 	assert.Equal(s.T(), 2, len(ucs.UseCaseInformation))
 	assert.Equal(s.T(), 1, len(ucs.UseCaseInformation[0].UseCaseSupport))
 
 	ucs.RemoveUseCaseSupport(
 		address,
-		UseCaseActorTypeCEM,
-		UseCaseNameTypeEVSECommissioningAndConfiguration,
+		UseCaseFilter{
+			Actor:       UseCaseActorTypeCEM,
+			UseCaseName: UseCaseNameTypeEVSECommissioningAndConfiguration,
+		},
 	)
 	assert.Equal(s.T(), 1, len(ucs.UseCaseInformation))
 
-	ucs.RemoveUseCaseSupport(
-		address,
-		"",
-		"",
-	)
+	ucs.RemoveUseCaseSupport(address, UseCaseFilter{})
 	assert.Equal(s.T(), 1, len(ucs.UseCaseInformation))
 
 	invalidAddress := FeatureAddressType{
@@ -121,8 +123,10 @@ func (s *NodeManagementUseCaseDataTypeSuite) Test_AdditionsAndRemovals() {
 	}
 	ucs.RemoveUseCaseSupport(
 		invalidAddress,
-		UseCaseActorTypeCEM,
-		UseCaseNameTypeEVSECommissioningAndConfiguration,
+		UseCaseFilter{
+			Actor:       UseCaseActorTypeCEM,
+			UseCaseName: UseCaseNameTypeEVSECommissioningAndConfiguration,
+		},
 	)
 	assert.Equal(s.T(), 1, len(ucs.UseCaseInformation))
 

--- a/spine/entity_local.go
+++ b/spine/entity_local.go
@@ -149,7 +149,7 @@ func (r *EntityLocal) AddUseCaseSupport(
 }
 
 // Check if a use case is already added
-func (r *EntityLocal) HasUseCaseSupport(actor model.UseCaseActorType, useCaseName model.UseCaseNameType) bool {
+func (r *EntityLocal) HasUseCaseSupport(uc model.UseCaseFilter) bool {
 	nodeMgmt := r.device.NodeManagement()
 
 	data, err := LocalFeatureDataCopyOfType[*model.NodeManagementUseCaseDataType](nodeMgmt, model.FunctionTypeNodeManagementUseCaseData)
@@ -162,14 +162,13 @@ func (r *EntityLocal) HasUseCaseSupport(actor model.UseCaseActorType, useCaseNam
 		Entity: r.address.Entity,
 	}
 
-	return data.HasUseCaseSupport(address, actor, useCaseName)
+	return data.HasUseCaseSupport(address, uc.Actor, uc.UseCaseName)
 }
 
 // Set the availability of a usecase. This may only be used for usescases
 // that act as a client within the usecase!
 func (r *EntityLocal) SetUseCaseAvailability(
-	actor model.UseCaseActorType,
-	useCaseName model.UseCaseNameType,
+	uc model.UseCaseFilter,
 	available bool) {
 	nodeMgmt := r.device.NodeManagement()
 
@@ -183,16 +182,17 @@ func (r *EntityLocal) SetUseCaseAvailability(
 		Entity: r.address.Entity,
 	}
 
-	data.SetAvailability(address, actor, useCaseName, available)
+	data.SetAvailability(address, uc.Actor, uc.UseCaseName, available)
 
 	nodeMgmt.SetData(model.FunctionTypeNodeManagementUseCaseData, data)
 }
 
-// Remove a usecase with a given actor ans usecase name
-func (r *EntityLocal) RemoveUseCaseSupport(
-	actor model.UseCaseActorType,
-	useCaseName model.UseCaseNameType,
-) {
+// Remove a usecase with a list of given actor and usecase name
+func (r *EntityLocal) RemoveUseCaseSupports(filters []model.UseCaseFilter) {
+	if len(filters) == 0 {
+		return
+	}
+
 	nodeMgmt := r.device.NodeManagement()
 
 	data, err := LocalFeatureDataCopyOfType[*model.NodeManagementUseCaseDataType](nodeMgmt, model.FunctionTypeNodeManagementUseCaseData)
@@ -205,7 +205,9 @@ func (r *EntityLocal) RemoveUseCaseSupport(
 		Entity: r.address.Entity,
 	}
 
-	data.RemoveUseCaseSupport(address, actor, useCaseName)
+	for _, item := range filters {
+		data.RemoveUseCaseSupport(address, item)
+	}
 
 	nodeMgmt.SetData(model.FunctionTypeNodeManagementUseCaseData, data)
 }

--- a/spine/entity_local_test.go
+++ b/spine/entity_local_test.go
@@ -57,8 +57,10 @@ func (suite *EntityLocalTestSuite) Test_Entity() {
 	entity.RemoveAllUseCaseSupports()
 
 	hasUC := entity.HasUseCaseSupport(
-		model.UseCaseActorTypeCEM,
-		model.UseCaseNameTypeEVSECommissioningAndConfiguration,
+		model.UseCaseFilter{
+			Actor:       model.UseCaseActorTypeCEM,
+			UseCaseName: model.UseCaseNameTypeEVSECommissioningAndConfiguration,
+		},
 	)
 	assert.Equal(suite.T(), false, hasUC)
 
@@ -77,10 +79,11 @@ func (suite *EntityLocalTestSuite) Test_Entity() {
 	_, err = LocalFeatureDataCopyOfType[*model.NodeManagementUseCaseDataType](device.NodeManagement(), model.FunctionTypeNodeManagementUseCaseData)
 	assert.Nil(suite.T(), err)
 
-	hasUC = entity.HasUseCaseSupport(
-		model.UseCaseActorTypeCEM,
-		model.UseCaseNameTypeEVSECommissioningAndConfiguration,
-	)
+	cemEvseUCFilter := model.UseCaseFilter{
+		Actor:       model.UseCaseActorTypeCEM,
+		UseCaseName: model.UseCaseNameTypeEVSECommissioningAndConfiguration,
+	}
+	hasUC = entity.HasUseCaseSupport(cemEvseUCFilter)
 	assert.Equal(suite.T(), true, hasUC)
 
 	entity.AddUseCaseSupport(
@@ -92,27 +95,20 @@ func (suite *EntityLocalTestSuite) Test_Entity() {
 		[]model.UseCaseScenarioSupportType{1, 2},
 	)
 
-	hasUC = entity.HasUseCaseSupport(
-		model.UseCaseActorTypeCEM,
-		model.UseCaseNameTypeEVSECommissioningAndConfiguration,
-	)
+	hasUC = entity.HasUseCaseSupport(cemEvseUCFilter)
 	assert.Equal(suite.T(), true, hasUC)
 
 	entity.SetUseCaseAvailability(
-		model.UseCaseActorTypeCEM,
-		model.UseCaseNameTypeEVSECommissioningAndConfiguration,
+		cemEvseUCFilter,
 		false,
 	)
 
-	entity.RemoveUseCaseSupport(
-		model.UseCaseActorTypeCEM,
-		model.UseCaseNameTypeEVSECommissioningAndConfiguration,
-	)
+	entity.RemoveUseCaseSupports([]model.UseCaseFilter{})
+	hasUC = entity.HasUseCaseSupport(cemEvseUCFilter)
+	assert.Equal(suite.T(), true, hasUC)
 
-	hasUC = entity.HasUseCaseSupport(
-		model.UseCaseActorTypeCEM,
-		model.UseCaseNameTypeEVSECommissioningAndConfiguration,
-	)
+	entity.RemoveUseCaseSupports([]model.UseCaseFilter{cemEvseUCFilter})
+	hasUC = entity.HasUseCaseSupport(cemEvseUCFilter)
 	assert.Equal(suite.T(), false, hasUC)
 
 	entity.AddUseCaseSupport(
@@ -124,18 +120,12 @@ func (suite *EntityLocalTestSuite) Test_Entity() {
 		[]model.UseCaseScenarioSupportType{1, 2},
 	)
 
-	hasUC = entity.HasUseCaseSupport(
-		model.UseCaseActorTypeCEM,
-		model.UseCaseNameTypeEVSECommissioningAndConfiguration,
-	)
+	hasUC = entity.HasUseCaseSupport(cemEvseUCFilter)
 	assert.Equal(suite.T(), true, hasUC)
 
 	entity.RemoveAllUseCaseSupports()
 
-	hasUC = entity.HasUseCaseSupport(
-		model.UseCaseActorTypeCEM,
-		model.UseCaseNameTypeEVSECommissioningAndConfiguration,
-	)
+	hasUC = entity.HasUseCaseSupport(cemEvseUCFilter)
 	assert.Equal(suite.T(), false, hasUC)
 
 	entity.RemoveAllBindings()


### PR DESCRIPTION
- Add API to remove multiple usecases in a single step
- Remove API to only remove a single usecase
- Update UseCase API calls, to use a new model.UseCaseFilter struct, which is used to invoke the action on all usecases matching the filter

Reasoning: Every individal usecase removal will trigger a SPINE message, and if multiple are remove, this triggers multiple messages which is not a desired outcome even though it would be valid. So the intention is to get only a single SPINE notify message with all removals already being part of.