### PR TITLE
Fix: HVAC System Function Operation Mode Selector

### DIFF
--- a/model/hvac.go
+++ b/model/hvac.go
@@ -89,7 +89,7 @@ type HvacSystemFunctionOperationModeRelationListDataType struct {
 }
 
 type HvacSystemFunctionOperationModeRelationListDataSelectorsType struct {
-	SystemFunctionId []HvacSystemFunctionIdType `json:"systemFunctionId,omitempty"`
+	SystemFunctionId *HvacSystemFunctionIdType `json:"systemFunctionId,omitempty"`
 }
 
 type HvacSystemFunctionSetpointRelationDataType struct {


### PR DESCRIPTION
This commit fixes the selector for `HvacSystemFunctionOperationModeRelationListDataSelectorsType`.

Before this commit, the `HvacSystemFunctionOperationModeRelationListDataSelectorsType`, was a list of `HvacSystemFunctionIdType` instead of a single element.

Now, `HvacSystemFunctionOperationModeRelationListDataSelectorsType`, has a single `HvacSystemFunctionIdType` instead of an array.

Resource specification **5.3.12.3.3**:
![image](https://github.com/user-attachments/assets/73752669-f1ee-4c61-91f3-6ceb1751a3e9)
