### PR TITLE
Add JSON Marshalling support to device and entity

### DIFF
--- a/spine/device.go
+++ b/spine/device.go
@@ -1,6 +1,10 @@
 package spine
 
-import "github.com/enbility/spine-go/model"
+import (
+	"encoding/json"
+
+	"github.com/enbility/spine-go/model"
+)
 
 type Device struct {
 	address    *model.AddressDeviceType
@@ -31,6 +35,26 @@ func NewDevice(address *model.AddressDeviceType, dType *model.DeviceTypeType, fe
 
 func (r *Device) Address() *model.AddressDeviceType {
 	return r.address
+}
+
+// Add support for JSON Marshalling
+//
+// Instances of EntityInterface are used as arguments and return values in various API calls,
+// therefor it is helpfull to be able to marshal them to JSON and thus make the API calls
+// usable with various communication interfaces
+func (r *Device) MarshalJSON() ([]byte, error) {
+	var tempAddress string
+
+	if r.address != nil {
+		tempAddress = string(*r.address)
+	}
+
+	bytes, err := json.Marshal(tempAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	return bytes, nil
 }
 
 func (r *Device) DeviceType() *model.DeviceTypeType {

--- a/spine/device_test.go
+++ b/spine/device_test.go
@@ -1,0 +1,35 @@
+package spine
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/enbility/spine-go/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestDeviceSuite(t *testing.T) {
+	suite.Run(t, new(DeviceTestSuite))
+}
+
+type DeviceTestSuite struct {
+	suite.Suite
+}
+
+func (s *DeviceTestSuite) Test_Device() {
+	deviceAddress := model.AddressDeviceType("test")
+	device := NewDevice(&deviceAddress, nil, nil)
+
+	value, err := json.Marshal(device)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), value)
+	assert.Equal(s.T(), `"test"`, string(value))
+
+	device = NewDevice(nil, nil, nil)
+
+	value, err = json.Marshal(device)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), value)
+	assert.Equal(s.T(), `""`, string(value))
+}

--- a/spine/entity_test.go
+++ b/spine/entity_test.go
@@ -1,0 +1,42 @@
+package spine
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/enbility/spine-go/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestEntitySuite(t *testing.T) {
+	suite.Run(t, new(EntityTestSuite))
+}
+
+type EntityTestSuite struct {
+	suite.Suite
+}
+
+func (s *EntityTestSuite) Test_Entity() {
+	deviceAddress := model.AddressDeviceType("test")
+	entity := NewEntity(model.EntityTypeTypeCEM, &deviceAddress, NewAddressEntityType([]uint{1, 1}))
+
+	value, err := json.Marshal(entity)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), value)
+	assert.Equal(s.T(), `{"Device":"test","Entity":[1,1]}`, string(value))
+
+	entity = NewEntity(model.EntityTypeTypeCEM, &deviceAddress, nil)
+
+	value, err = json.Marshal(entity)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), value)
+	assert.Equal(s.T(), `{"Device":"test","Entity":null}`, string(value))
+
+	entity = NewEntity(model.EntityTypeTypeCEM, nil, nil)
+
+	value, err = json.Marshal(entity)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), value)
+	assert.Equal(s.T(), `{"Device":"","Entity":null}`, string(value))
+}


### PR DESCRIPTION
Both DeviceInterface and EntityInterface implementations (e.g. DeviceRemoteInterface and EntityRemoteInterface) are used as arguments in API calls and return values.

When these API calls are used via interprocess communication protocols based on JSON, then the easiest way is to convert them into their addresses to be identified.

This change adds support for this need.