### PR TITLE
Maintenance updates

### DIFF
--- a/model/commondatatypes.go
+++ b/model/commondatatypes.go
@@ -158,7 +158,7 @@ type ScaledNumberSetElementsType struct {
 
 type NumberType int64
 
-type ScaleType int8
+type ScaleType int16
 
 type ScaledNumberType struct {
 	Number *NumberType `json:"number,omitempty"`

--- a/spine/device_local.go
+++ b/spine/device_local.go
@@ -141,6 +141,12 @@ func (r *DeviceLocal) AddRemoteDeviceForSki(ski string, rDevice api.DeviceRemote
 func (r *DeviceLocal) RemoveRemoteDeviceConnection(ski string) {
 	remoteDevice := r.RemoteDeviceForSki(ski)
 
+	// we get the events for any disconnection, even for cases where SHIP
+	// closed a connection and therefor it never reached SPINE
+	if remoteDevice == nil {
+		return
+	}
+
 	r.RemoveRemoteDevice(ski)
 
 	// inform about the disconnection

--- a/spine/device_local_test.go
+++ b/spine/device_local_test.go
@@ -39,6 +39,11 @@ func (d *DeviceLocalTestSuite) Test_RemoveRemoteDevice() {
 
 	rDevice = sut.RemoteDeviceForSki(ski)
 	assert.Nil(d.T(), rDevice)
+
+	// removing twice should not trigger anything
+	sut.RemoveRemoteDeviceConnection(ski)
+	rDevice = sut.RemoteDeviceForSki(ski)
+	assert.Nil(d.T(), rDevice)
 }
 
 func (d *DeviceLocalTestSuite) Test_RemoteDevice() {


### PR DESCRIPTION
- Fix data type of 'ScaleType'
- Do not send disconnect events, if the remote ski is not found as an existing remote device
