### PR TITLE
Fix merge of spine data types when messages arrive with unset identifiers

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ^1.21
+          go-version: ^1.22
 
       - name: Build
         run: go build -v ./...
@@ -32,8 +32,6 @@ jobs:
         uses: golangci/golangci-lint-action@master
         with:
           version: latest
-          skip-pkg-cache: true
-          skip-build-cache: true
           args: --timeout=3m --issues-exit-code=0 ./...
 
       - name: Test

--- a/integration_tests/helper_test.go
+++ b/integration_tests/helper_test.go
@@ -154,3 +154,26 @@ func waitForAck(t *testing.T, msgCounterReference *model.MsgCounterType, writeHa
 		}
 	}
 }
+
+// When using waitForNack and waitForAck in the same test ensure that each message sent has a unique message counter
+func waitForNack(t *testing.T, msgCounterReference *model.MsgCounterType, writeHandler *WriteMessageHandler) {
+	var datagram model.Datagram
+
+	msg := writeHandler.ResultWithReference(msgCounterReference)
+	if msg == nil {
+		t.Fatal("acknowledge message was not sent!!")
+	}
+
+	if err := json.Unmarshal(msg, &datagram); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := datagram.Datagram.Payload.Cmd[0]
+	if cmd.ResultData != nil {
+		if cmd.ResultData.ErrorNumber == nil || uint(*cmd.ResultData.ErrorNumber) == uint(model.ErrorNumberTypeNoError) {
+			t.Fatal("expected error in acknowledgement but received nil/no error")
+		}
+	} else {
+		t.Fatal("expected ResultData with error in acknowledgement but received no ResultData")
+	}
+}

--- a/integration_tests/measurement_test.go
+++ b/integration_tests/measurement_test.go
@@ -17,7 +17,7 @@ const (
 	m_measurementListData_recv_notify_file_path     = "./testdata/m_measurementListData_recv_notify.json"
 	m_measurementListData_set_key_path              = "./testdata/m_measurementListData_set_key.json"
 	m_measurementListData_unset_key_path            = "./testdata/m_measurementListData_unset_key.json"
-	m_measurementListData_unset_key_filter_path		= "./testdata/m_measurementListData_unset_key_with_filter.json"
+	m_measurementListData_unset_key_filter_path     = "./testdata/m_measurementListData_unset_key_with_filter.json"
 )
 
 func TestMeasurementSuite(t *testing.T) {
@@ -144,7 +144,7 @@ func (s *MeasurementSuite) TestMeasurementUnsetKey() {
 	data := fdata.(*model.MeasurementListDataType)
 
 	// The 3 unset measurements should have been ignored and not merged => Value should stay unchanged
-	assert.Equal(s.T(), 5.0, data.MeasurementData[0].Value.GetValue()) 
+	assert.Equal(s.T(), 5.0, data.MeasurementData[0].Value.GetValue())
 }
 
 func (s *MeasurementSuite) TestMeasurementByScope_Recv() {

--- a/integration_tests/measurement_test.go
+++ b/integration_tests/measurement_test.go
@@ -17,6 +17,7 @@ const (
 	m_measurementListData_recv_notify_file_path     = "./testdata/m_measurementListData_recv_notify.json"
 	m_measurementListData_set_key_path              = "./testdata/m_measurementListData_set_key.json"
 	m_measurementListData_unset_key_path            = "./testdata/m_measurementListData_unset_key.json"
+	m_measurementListData_unset_key_filter_path		= "./testdata/m_measurementListData_unset_key_with_filter.json"
 )
 
 func TestMeasurementSuite(t *testing.T) {
@@ -117,11 +118,15 @@ func (s *MeasurementSuite) TestMeasurementList_Recv() {
 func (s *MeasurementSuite) TestMeasurementUnsetKey() {
 	// Send measurements with everything except MeasurementID set to nil
 	msgCounter, _ := s.remoteDevice.HandleSpineMesssage(loadFileData(s.T(), m_measurementListData_unset_key_path))
-	waitForAck(s.T(), msgCounter, s.writeHandler)
+	waitForNack(s.T(), msgCounter, s.writeHandler)
 
-	// Then send proper measurements
+	// Send proper measurements
 	msgCounter, _ = s.remoteDevice.HandleSpineMesssage(loadFileData(s.T(), m_measurementListData_set_key_path))
 	waitForAck(s.T(), msgCounter, s.writeHandler)
+
+	// Try to merge data with unset keys by providing partial filter
+	msgCounter, _ = s.remoteDevice.HandleSpineMesssage(loadFileData(s.T(), m_measurementListData_unset_key_filter_path))
+	waitForNack(s.T(), msgCounter, s.writeHandler)
 
 	remoteDevice := s.sut.RemoteDeviceForSki(s.remoteSki)
 	assert.NotNil(s.T(), remoteDevice)
@@ -138,10 +143,8 @@ func (s *MeasurementSuite) TestMeasurementUnsetKey() {
 	}
 	data := fdata.(*model.MeasurementListDataType)
 
-	// The 3 unset measurements should be overwritten/merged or ignored => there should be a total of 3 measurements
-	if !assert.Equal(s.T(), 3, len(data.MeasurementData)) {
-		return
-	}
+	// The 3 unset measurements should have been ignored and not merged => Value should stay unchanged
+	assert.Equal(s.T(), 5.0, data.MeasurementData[0].Value.GetValue()) 
 }
 
 func (s *MeasurementSuite) TestMeasurementByScope_Recv() {

--- a/integration_tests/measurement_test.go
+++ b/integration_tests/measurement_test.go
@@ -138,7 +138,7 @@ func (s *MeasurementSuite) TestMeasurementUnsetKey() {
 	}
 	data := fdata.(*model.MeasurementListDataType)
 
-	// If correctly merged the first 3 unset measurements are overwritten with new measurements
+	// The 3 unset measurements should be overwritten/merged or ignored => there should be a total of 3 measurements
 	if !assert.Equal(s.T(), 3, len(data.MeasurementData)) {
 		return
 	}

--- a/integration_tests/measurement_test.go
+++ b/integration_tests/measurement_test.go
@@ -15,6 +15,8 @@ const (
 	m_subscriptionRequestCall_recv_result_file_path = "./testdata/m_subscriptionRequestCall_recv_result.json"
 	m_descriptionListData_recv_reply_file_path      = "./testdata/m_descriptionListData_recv_reply.json"
 	m_measurementListData_recv_notify_file_path     = "./testdata/m_measurementListData_recv_notify.json"
+	m_measurementListData_set_key_path              = "./testdata/m_measurementListData_set_key.json"
+	m_measurementListData_unset_key_path            = "./testdata/m_measurementListData_unset_key.json"
 )
 
 func TestMeasurementSuite(t *testing.T) {
@@ -110,6 +112,36 @@ func (s *MeasurementSuite) TestMeasurementList_Recv() {
 		2022, 11, 19, 15, 21, 50, 3000000, time.UTC)
 	assert.Equal(s.T(), compareTimestamp, timestamp)
 	assert.Equal(s.T(), string(model.MeasurementValueSourceTypeMeasuredValue), string(*item1.ValueSource))
+}
+
+func (s *MeasurementSuite) TestMeasurementUnsetKey() {
+	// Send measurements with everything except MeasurementID set to nil
+	msgCounter, _ := s.remoteDevice.HandleSpineMesssage(loadFileData(s.T(), m_measurementListData_unset_key_path))
+	waitForAck(s.T(), msgCounter, s.writeHandler)
+
+	// Then send proper measurements
+	msgCounter, _ = s.remoteDevice.HandleSpineMesssage(loadFileData(s.T(), m_measurementListData_set_key_path))
+	waitForAck(s.T(), msgCounter, s.writeHandler)
+
+	remoteDevice := s.sut.RemoteDeviceForSki(s.remoteSki)
+	assert.NotNil(s.T(), remoteDevice)
+
+	mFeature := remoteDevice.FeatureByEntityTypeAndRole(
+		remoteDevice.Entity(spine.NewAddressEntityType([]uint{1, 1})),
+		model.FeatureTypeTypeMeasurement,
+		model.RoleTypeServer)
+	assert.NotNil(s.T(), mFeature)
+
+	fdata := mFeature.DataCopy(model.FunctionTypeMeasurementListData)
+	if !assert.NotNil(s.T(), fdata) {
+		return
+	}
+	data := fdata.(*model.MeasurementListDataType)
+
+	// If correctly merged the first 3 unset measurements are overwritten with new measurements
+	if !assert.Equal(s.T(), 3, len(data.MeasurementData)) {
+		return
+	}
 }
 
 func (s *MeasurementSuite) TestMeasurementByScope_Recv() {

--- a/integration_tests/testdata/m_measurementListData_set_key.json
+++ b/integration_tests/testdata/m_measurementListData_set_key.json
@@ -1,0 +1,68 @@
+{
+  "datagram": {
+    "header": {
+      "specificationVersion": "1.1.1",
+      "addressSource": {
+        "device": "Wallbox",
+        "entity": [1,1],
+        "feature": 11
+      },
+      "addressDestination": {
+        "device": "HEMS",
+        "entity": [1],
+        "feature": 2
+      },
+      "msgCounter": 10,
+      "cmdClassifier": "notify",
+      "ackRequest":true
+    },
+    "payload": {
+      "cmd": [
+        {
+          "function": "measurementListData",
+          "filter": [
+            {
+              "cmdControl":{
+                "partial": {}
+              }
+            }
+          ],
+          "measurementListData": {
+            "measurementData": [
+              {
+                "measurementId": 0,
+                "valueType": "value",
+                "timestamp": "2025-01-09T13:27:50.003Z",
+                "value": {
+                  "number": 5,
+                  "scale": 0
+                },
+                "valueSource": "measuredValue"
+              },
+              {
+                "measurementId": 1,
+                "valueType": "value",
+                "timestamp": "2025-01-09T13:27:50.003Z",
+                "value": {
+                  "number": 1185,
+                  "scale": 0
+                },
+                "valueSource": "measuredValue"
+              },
+              {
+                "measurementId": 2,
+                "valueType": "value",
+                "timestamp": "2025-01-09T13:27:50.003Z",
+                "value": {
+                  "number": 1825,
+                  "scale": 0
+                },
+                "valueSource": "measuredValue"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/integration_tests/testdata/m_measurementListData_set_key.json
+++ b/integration_tests/testdata/m_measurementListData_set_key.json
@@ -12,7 +12,7 @@
         "entity": [1],
         "feature": 2
       },
-      "msgCounter": 10,
+      "msgCounter": 11,
       "cmdClassifier": "notify",
       "ackRequest":true
     },

--- a/integration_tests/testdata/m_measurementListData_unset_key.json
+++ b/integration_tests/testdata/m_measurementListData_unset_key.json
@@ -1,0 +1,41 @@
+{
+    "datagram": {
+      "header": {
+        "specificationVersion": "1.1.1",
+        "addressSource": {
+          "device": "Wallbox",
+          "entity": [1,1],
+          "feature": 11
+        },
+        "addressDestination": {
+          "device": "HEMS",
+          "entity": [1],
+          "feature": 2
+        },
+        "msgCounter": 10,
+        "cmdClassifier": "notify",
+        "ackRequest":true
+      },
+      "payload": {
+        "cmd": [
+          {
+            "function": "measurementListData",
+            "measurementListData": {
+              "measurementData": [
+                {
+                  "measurementId": 0
+                },
+                {
+                  "measurementId": 1
+                },
+                {
+                  "measurementId": 3
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+  

--- a/integration_tests/testdata/m_measurementListData_unset_key_with_filter.json
+++ b/integration_tests/testdata/m_measurementListData_unset_key_with_filter.json
@@ -1,0 +1,47 @@
+{
+  "datagram": {
+    "header": {
+      "specificationVersion": "1.1.1",
+      "addressSource": {
+        "device": "Wallbox",
+        "entity": [1,1],
+        "feature": 11
+      },
+      "addressDestination": {
+        "device": "HEMS",
+        "entity": [1],
+        "feature": 2
+      },
+      "msgCounter": 12,
+      "cmdClassifier": "notify",
+      "ackRequest":true
+    },
+    "payload": {
+      "cmd": [
+        {
+          "function": "measurementListData",
+          "filter": [
+            {
+              "cmdControl":{
+                "partial": {}
+              }
+            }
+          ],
+          "measurementListData": {
+            "measurementData": [
+              {
+                "measurementId": 0
+              },
+              {
+                "measurementId": 1
+              },
+              {
+                "measurementId": 2
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/model/update.go
+++ b/model/update.go
@@ -88,7 +88,7 @@ func UpdateList[T any](remoteWrite bool, existingData []T, newData []T, filterPa
 		if HasNoIdentifiers(item) {
 			// no identifiers specified --> copy data to all existing items
 			// (see EEBus_SPINE_TS_ProtocolSpecification.pdf, Table 7: Considered cmdOptions combinations for classifier "notify")
-			updatedData, noErrors = copyToAllData(remoteWrite, updatedData, &item)
+			updatedData, noErrors = copyToAllData(remoteWrite, updatedData, &item) // #nosec G601 pointers are dereferenced within each loop iteration via reflection, no aliasing can occur and since go1.22 aliasing doesn't happen in loops regardless
 			if !noErrors {
 				success = false
 			}

--- a/model/update.go
+++ b/model/update.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"sort"
 
+	"github.com/enbility/ship-go/logging"
 	"github.com/enbility/spine-go/util"
 )
 
@@ -35,6 +36,21 @@ type Updater interface {
 func UpdateList[T any](remoteWrite bool, existingData []T, newData []T, filterPartial, filterDelete *FilterType) ([]T, bool) {
 	success := true
 
+	if filterDelete == nil && filterPartial == nil {
+		if len(newData) == 0 {
+			return newData, success
+		}
+		// filter invalid data out and simply return all new data left
+		newData = filterIncompleteIdentifiers(newData)
+		if len(newData) == 0 {
+			logging.Log().Debug("provided list only contains invalid items, leaving old data unchanged")
+			return existingData, false
+		}
+
+		result := SortData(newData)
+		return result, success
+	}
+
 	// process delete filter (with selectors and elements)
 	if filterDelete != nil {
 		if filterData, err := filterDelete.Data(); err == nil {
@@ -59,9 +75,7 @@ func UpdateList[T any](remoteWrite bool, existingData []T, newData []T, filterPa
 	}
 
 	// check if items have no identifiers
-	// Currently all fields marked as key are required
-	// TODO: check how to handle if only one identifier is provided
-	if len(newData) > 0 && !HasIdentifiers(newData[0]) {
+	if len(newData) > 0 && HasNoIdentifiers(newData[0]) {
 		// no identifiers specified --> copy data to all existing items
 		// (see EEBus_SPINE_TS_ProtocolSpecification.pdf, Table 7: Considered cmdOptions combinations for classifier "notify")
 		newData, noErrors := copyToAllData(remoteWrite, existingData, &newData[0])
@@ -71,6 +85,8 @@ func UpdateList[T any](remoteWrite bool, existingData []T, newData []T, filterPa
 		return newData, success
 	}
 
+	// Items with some (but not all identifiers) set need to be filtered out as they are invalid
+	newData = filterIncompleteIdentifiers(newData)
 	result, noErrors := Merge(remoteWrite, existingData, newData)
 	if !noErrors {
 		success = false
@@ -79,6 +95,20 @@ func UpdateList[T any](remoteWrite bool, existingData []T, newData []T, filterPa
 	result = SortData(result)
 
 	return result, success
+}
+
+// Filter out all items that do not have complete identifiers
+func filterIncompleteIdentifiers[T any](data []T) []T {
+	var filteredItems []T
+	for _, item := range data {
+		if HasAllIdentifiers(item) {
+			filteredItems = append(filteredItems, item)
+		} else {
+			logging.Log().Debug("an item in list of new data does not have all identifiers set and will thus be ignored")
+		}
+	}
+
+	return filteredItems
 }
 
 // return a list of field names that have the eebus tag
@@ -112,7 +142,29 @@ func fieldNamesWithEEBusTag(tag EEBusTag, item any) []string {
 	return result
 }
 
-func HasIdentifiers(data any) bool {
+// Checks if none of an items identifiers are set if it has any
+func HasNoIdentifiers(data any) bool {
+	keys := fieldNamesWithEEBusTag(EEBusTagKey, data)
+
+	// If item has no fields with tag 'key' then those fields can't be 'missing' or 'unset'
+	if len(keys) == 0 {
+		return false
+	}
+
+	v := reflect.ValueOf(data)
+
+	for _, fieldName := range keys {
+		f := v.FieldByName(fieldName)
+
+		if !f.IsNil() {
+			return false
+		}
+	}
+
+	return true
+}
+
+func HasAllIdentifiers(data any) bool {
 	keys := fieldNamesWithEEBusTag(EEBusTagKey, data)
 
 	v := reflect.ValueOf(data)

--- a/model/update.go
+++ b/model/update.go
@@ -36,14 +36,18 @@ type Updater interface {
 func UpdateList[T any](remoteWrite bool, existingData []T, newData []T, filterPartial, filterDelete *FilterType) ([]T, bool) {
 	success := true
 
+	if !listIsValid(newData) {
+		logging.Log().Debug("incoming list update for type '%s' contains invalid items (some but not all identifiers set), leaving old data unchanged", util.Type[T]().Name())
+		return existingData, false
+	}
+
 	if filterDelete == nil && filterPartial == nil {
 		if len(newData) == 0 {
 			return newData, success
 		}
-		// filter invalid data out and simply return all new data left
-		newData = filterIncompleteIdentifiers(newData)
-		if len(newData) == 0 {
-			logging.Log().Debug("provided list only contains invalid items, leaving old data unchanged")
+		// because no filters are set all items need to have complete identifiers
+		if !listHasAllIdentifiers(newData) {
+			logging.Log().Debug("no filters were set and incoming list update for type '%s' contains items that do not have all identifiers, leaving old data unchanged", util.Type[T]().Name())
 			return existingData, false
 		}
 
@@ -78,46 +82,47 @@ func UpdateList[T any](remoteWrite bool, existingData []T, newData []T, filterPa
 		return existingData, success
 	}
 
-	// check if items have no identifiers
-	if HasNoIdentifiers(newData[0]) {
-		// no identifiers specified --> copy data to all existing items
-		// (see EEBus_SPINE_TS_ProtocolSpecification.pdf, Table 7: Considered cmdOptions combinations for classifier "notify")
-		newData, noErrors := copyToAllData(remoteWrite, existingData, &newData[0])
-		if !noErrors {
-			success = false
+	updatedData := existingData
+	for _, item := range newData {
+		var noErrors bool
+		if HasNoIdentifiers(item) {
+			// no identifiers specified --> copy data to all existing items
+			// (see EEBus_SPINE_TS_ProtocolSpecification.pdf, Table 7: Considered cmdOptions combinations for classifier "notify")
+			updatedData, noErrors = copyToAllData(remoteWrite, updatedData, &item)
+			if !noErrors {
+				success = false
+			}
+		} else {
+			updatedData, noErrors = Merge(remoteWrite, updatedData, []T{item})
+			if !noErrors {
+				success = false
+			}
 		}
-		return newData, success
 	}
 
-	// Items with some (but not all identifiers) set need to be filtered out as they are invalid
-	newData = filterIncompleteIdentifiers(newData)
-	if len(newData) == 0 {
-		logging.Log().Debug("provided list only contains invalid items, leaving old data unchanged")
-		return existingData, false
-	}
-	
-	result, noErrors := Merge(remoteWrite, existingData, newData)
-	if !noErrors {
-		success = false
-	}
-
-	result = SortData(result)
+	result := SortData(updatedData)
 
 	return result, success
 }
 
-// Filter out all items that do not have complete identifiers
-func filterIncompleteIdentifiers[T any](data []T) []T {
-	var filteredItems []T
+// Check if every item in list has either all or no identifiers set
+func listIsValid[T any](data []T) bool {
 	for _, item := range data {
-		if HasAllIdentifiers(item) {
-			filteredItems = append(filteredItems, item)
-		} else {
-			logging.Log().Debug("an item in list of new data does not have all identifiers set and will thus be ignored")
+		if !HasAllIdentifiers(item) && !HasNoIdentifiers(item) {
+			return false
 		}
 	}
+	return true
+}
 
-	return filteredItems
+// Check if all items in a list have all of their identifiers
+func listHasAllIdentifiers[T any](data []T) bool {
+	for _, item := range data {
+		if !HasAllIdentifiers(item) {
+			return false
+		}
+	}
+	return true
 }
 
 // return a list of field names that have the eebus tag

--- a/model/update.go
+++ b/model/update.go
@@ -74,8 +74,12 @@ func UpdateList[T any](remoteWrite bool, existingData []T, newData []T, filterPa
 		}
 	}
 
+	if len(newData) == 0 {
+		return existingData, success
+	}
+
 	// check if items have no identifiers
-	if len(newData) > 0 && HasNoIdentifiers(newData[0]) {
+	if HasNoIdentifiers(newData[0]) {
 		// no identifiers specified --> copy data to all existing items
 		// (see EEBus_SPINE_TS_ProtocolSpecification.pdf, Table 7: Considered cmdOptions combinations for classifier "notify")
 		newData, noErrors := copyToAllData(remoteWrite, existingData, &newData[0])
@@ -87,6 +91,11 @@ func UpdateList[T any](remoteWrite bool, existingData []T, newData []T, filterPa
 
 	// Items with some (but not all identifiers) set need to be filtered out as they are invalid
 	newData = filterIncompleteIdentifiers(newData)
+	if len(newData) == 0 {
+		logging.Log().Debug("provided list only contains invalid items, leaving old data unchanged")
+		return existingData, false
+	}
+	
 	result, noErrors := Merge(remoteWrite, existingData, newData)
 	if !noErrors {
 		success = false

--- a/model/update_test.go
+++ b/model/update_test.go
@@ -19,13 +19,14 @@ type TestUpdater struct {
 }
 
 func TestUpdateList_NewItem(t *testing.T) {
+	partialFilter := NewFilterTypePartial()
 	existingData := []TestUpdateData{{Id: util.Ptr(uint(1)), DataItem: util.Ptr(int(1))}}
 	newData := []TestUpdateData{{Id: util.Ptr(uint(2)), DataItem: util.Ptr(int(2))}}
 
 	expectedResult := []TestUpdateData{{Id: util.Ptr(uint(1)), DataItem: util.Ptr(int(1))}, {Id: util.Ptr(uint(2)), DataItem: util.Ptr(int(2))}}
 
 	// Act
-	result, boolV := UpdateList(false, existingData, newData, nil, nil)
+	result, boolV := UpdateList(false, existingData, newData, partialFilter, nil)
 
 	assert.True(t, boolV)
 	assert.Equal(t, expectedResult, result)
@@ -33,20 +34,21 @@ func TestUpdateList_NewItem(t *testing.T) {
 	expectedResult = []TestUpdateData{{Id: util.Ptr(uint(1)), DataItem: util.Ptr(int(1))}}
 
 	// Act
-	result, boolV = UpdateList(true, existingData, newData, nil, nil)
+	result, boolV = UpdateList(true, existingData, newData, partialFilter, nil)
 
 	assert.False(t, boolV)
 	assert.Equal(t, expectedResult, result)
 }
 
 func TestUpdateList_ChangedItem(t *testing.T) {
+	partialFilter := NewFilterTypePartial()
 	existingData := []TestUpdateData{{Id: util.Ptr(uint(1)), IsChangeable: util.Ptr(false), DataItem: util.Ptr(int(1))}}
 	newData := []TestUpdateData{{Id: util.Ptr(uint(1)), DataItem: util.Ptr(int(2))}}
 
 	expectedResult := []TestUpdateData{{Id: util.Ptr(uint(1)), IsChangeable: util.Ptr(false), DataItem: util.Ptr(int(2))}}
 
 	// Act
-	result, boolV := UpdateList(false, existingData, newData, nil, nil)
+	result, boolV := UpdateList(false, existingData, newData, partialFilter, nil)
 
 	assert.True(t, boolV)
 	assert.Equal(t, expectedResult, result)
@@ -54,20 +56,21 @@ func TestUpdateList_ChangedItem(t *testing.T) {
 	expectedResult = []TestUpdateData{{Id: util.Ptr(uint(1)), IsChangeable: util.Ptr(false), DataItem: util.Ptr(int(1))}}
 
 	// Act
-	result, boolV = UpdateList(true, existingData, newData, nil, nil)
+	result, boolV = UpdateList(true, existingData, newData, partialFilter, nil)
 
 	assert.False(t, boolV)
 	assert.Equal(t, expectedResult, result)
 }
 
 func TestUpdateList_NewAndChangedItem(t *testing.T) {
+	partialFilter := NewFilterTypePartial()
 	existingData := []TestUpdateData{{Id: util.Ptr(uint(1)), DataItem: util.Ptr(int(1))}}
 	newData := []TestUpdateData{{Id: util.Ptr(uint(1)), DataItem: util.Ptr(int(2))}, {Id: util.Ptr(uint(3)), DataItem: util.Ptr(int(3))}}
 
 	expectedResult := []TestUpdateData{{Id: util.Ptr(uint(1)), DataItem: util.Ptr(int(2))}, {Id: util.Ptr(uint(3)), DataItem: util.Ptr(int(3))}}
 
 	// Act
-	result, boolV := UpdateList(false, existingData, newData, nil, nil)
+	result, boolV := UpdateList(false, existingData, newData, partialFilter, nil)
 
 	assert.True(t, boolV)
 	assert.Equal(t, expectedResult, result)
@@ -75,20 +78,21 @@ func TestUpdateList_NewAndChangedItem(t *testing.T) {
 	expectedResult = []TestUpdateData{{Id: util.Ptr(uint(1)), DataItem: util.Ptr(int(1))}}
 
 	// Act
-	result, boolV = UpdateList(true, existingData, newData, nil, nil)
+	result, boolV = UpdateList(true, existingData, newData, partialFilter, nil)
 
 	assert.False(t, boolV)
 	assert.Equal(t, expectedResult, result)
 }
 
 func TestUpdateList_ItemWithNoIdentifier(t *testing.T) {
+	partialFilter := NewFilterTypePartial()
 	existingData := []TestUpdateData{{Id: util.Ptr(uint(1)), DataItem: util.Ptr(int(1))}, {Id: util.Ptr(uint(2)), DataItem: util.Ptr(int(2))}}
 	newData := []TestUpdateData{{DataItem: util.Ptr(int(3))}}
 
 	expectedResult := []TestUpdateData{{Id: util.Ptr(uint(1)), DataItem: util.Ptr(int(3))}, {Id: util.Ptr(uint(2)), DataItem: util.Ptr(int(3))}}
 
 	// Act
-	result, boolV := UpdateList(false, existingData, newData, nil, nil)
+	result, boolV := UpdateList(false, existingData, newData, partialFilter, nil)
 
 	assert.True(t, boolV)
 	assert.Equal(t, expectedResult, result)
@@ -96,7 +100,7 @@ func TestUpdateList_ItemWithNoIdentifier(t *testing.T) {
 	expectedResult = []TestUpdateData{{Id: util.Ptr(uint(1)), DataItem: util.Ptr(int(3))}, {Id: util.Ptr(uint(2)), DataItem: util.Ptr(int(3))}}
 
 	// Act
-	result, boolV = UpdateList(true, existingData, newData, nil, nil)
+	result, boolV = UpdateList(true, existingData, newData, partialFilter, nil)
 
 	assert.False(t, boolV)
 	assert.Equal(t, expectedResult, result)

--- a/model/update_test.go
+++ b/model/update_test.go
@@ -13,6 +13,13 @@ type TestUpdateData struct {
 	DataItem     *int
 }
 
+type TestUpdateDataMultiKey struct {
+	Id           *uint   `eebus:"key"`
+	DataType     *string `eebus:"key"`
+	IsChangeable *bool   `eebus:"writecheck"`
+	DataItem     *int
+}
+
 type TestUpdater struct {
 	// updateSelectorHashKey *string
 	// deleteSelectorHashKey *string
@@ -103,6 +110,40 @@ func TestUpdateList_ItemWithNoIdentifier(t *testing.T) {
 	result, boolV = UpdateList(true, existingData, newData, partialFilter, nil)
 
 	assert.False(t, boolV)
+	assert.Equal(t, expectedResult, result)
+}
+
+func TestUpdateList_ItemWithSomeIdentifiers(t *testing.T) {
+	partialFilter := NewFilterTypePartial()
+	existingData := []TestUpdateDataMultiKey{{Id: util.Ptr(uint(1)), DataItem: util.Ptr(int(1)), DataType: util.Ptr("testType")}}
+	newData := []TestUpdateDataMultiKey{{Id: util.Ptr(uint(2)), DataItem: util.Ptr(int(1))}, {Id: util.Ptr(uint(2)), DataItem: util.Ptr(int(2)), DataType: util.Ptr("testType")}}
+
+	expectedResult := existingData
+
+	result, boolV := UpdateList(false, existingData, newData, partialFilter, nil)
+
+	assert.False(t, boolV)
+	assert.Equal(t, expectedResult, result)
+}
+
+func TestUpdateList_ItemsWithNoAndAllIdentifiers(t *testing.T) {
+	partialFilter := NewFilterTypePartial()
+	existingData := []TestUpdateData{{Id: util.Ptr(uint(1)), DataItem: util.Ptr(int(1))}}
+	newData := []TestUpdateData{{DataItem: util.Ptr(int(2))}, {Id: util.Ptr(uint(2)), DataItem: util.Ptr(int(3))}}
+
+	expectedResult := []TestUpdateData{{Id: util.Ptr(uint(1)), DataItem: util.Ptr(int(2))}, {Id: util.Ptr(uint(2)), DataItem: util.Ptr(int(3))}}
+
+	result, boolV := UpdateList(false, existingData, newData, partialFilter, nil)
+
+	assert.True(t, boolV)
+	assert.Equal(t, expectedResult, result)
+
+	newData = []TestUpdateData{{Id: util.Ptr(uint(2)), DataItem: util.Ptr(int(3))}, {DataItem: util.Ptr(int(2))}}
+	expectedResult = []TestUpdateData{{Id: util.Ptr(uint(1)), DataItem: util.Ptr(int(2))}, {Id: util.Ptr(uint(2)), DataItem: util.Ptr(int(2))}}
+
+	result, boolV = UpdateList(false, existingData, newData, partialFilter, nil)
+
+	assert.True(t, boolV)
 	assert.Equal(t, expectedResult, result)
 }
 

--- a/spine/function_data.go
+++ b/spine/function_data.go
@@ -62,10 +62,9 @@ func (r *FunctionData[T]) UpdateData(remoteWrite, persist bool, newData *T, filt
 			// just set the data
 			r.data = newData
 			return r.data, nil
-		} else {
-			logging.Log().Debug("the provided new data does not have all identifiers set and will thus be ignored")
-			return r.data, nil
 		}
+		logging.Log().Debug("the provided new data does not have all identifiers set and will thus be ignored")
+		return r.data, nil
 	}
 
 	if !r.SupportsPartialWrite() {

--- a/spine/function_data.go
+++ b/spine/function_data.go
@@ -63,7 +63,7 @@ func (r *FunctionData[T]) UpdateData(remoteWrite, persist bool, newData *T, filt
 			r.data = newData
 			return r.data, nil
 		}
-		logging.Log().Debug("the provided new data does not have all identifiers set and will thus be ignored")
+		logging.Log().Debug("incoming new data of type '%s' does not have all identifiers set, leaving old data unchanged", util.Type[T]().Name())
 		return r.data, nil
 	}
 

--- a/spine/function_data.go
+++ b/spine/function_data.go
@@ -56,10 +56,16 @@ func (r *FunctionData[T]) UpdateData(remoteWrite, persist bool, newData *T, filt
 	r.mux.Lock()
 	defer r.mux.Unlock()
 
-	if filterPartial == nil && filterDelete == nil && persist {
-		// just set the data
-		r.data = newData
-		return r.data, nil
+	// Only non list data is handled here
+	if filterPartial == nil && filterDelete == nil && persist && !r.SupportsPartialWrite() {
+		if model.HasAllIdentifiers(newData) {
+			// just set the data
+			r.data = newData
+			return r.data, nil
+		} else {
+			logging.Log().Debug("the provided new data does not have all identifiers set and will thus be ignored")
+			return r.data, nil
+		}
 	}
 
 	if !r.SupportsPartialWrite() {


### PR DESCRIPTION
When a device sends e.g. a measurementListData response containing incomplete identifiers, and then sends a second measurementListData response containing complete identifiers the data from the second response is not correctly merged with the first response and queries to measurements by ID will always return the value of the first incomplete response and will never update to later values.

Our current approach implemented in this PR is to reject (negative acknowledgement) spine updates containing incomplete identifiers because to my knowledge devices really shouldn't be sending spine messages with incomplete identifiers (and to preclude needing to write a general merge function for generic spine data with potentially incomplete identifiers).

Commit bd9e7c89 adds a (initially failing) test for this scenario to help in reproduction and I've attached trace logs of this scenario happening on a real system below:
```
2024-12-17 16:05:40 TRACE Recv: *ski* {"data":[{"header":[{"protocolId":"ee1.0"}]},{"payload":{"datagram":[{"header":[{"specificationVersion":"1.3.0"},{"addressSource":[{"device":"d:_i:*device_id*"},{"entity":[1,1]},{"feature":11}]},{"addressDestination":[{"device":"d:_n:*device_id*"},{"entity":[2]},{"feature":9}]},{"msgCounter":60},{"msgCounterReference":26},{"cmdClassifier":"reply"}]},{"payload":[{"cmd":[[{"measurementListData":[{"measurementData":[[{"measurementId":0}],[{"measurementId":7}],[{"measurementId":8}],[{"measurementId":9}],[{"measurementId":4}],[{"measurementId":5}],[{"measurementId":1}],[{"measurementId":2}],[{"measurementId":3}],[{"measurementId":11}],[{"measurementId":13}],[{"measurementId":15}],[{"measurementId":10}],[{"measurementId":12}],[{"measurementId":14}],[{"measurementId":6}]]}]}]]}]}]}}]}

2024-12-17 16:05:50 TRACE Recv: *ski* {"data":[{"header":[{"protocolId":"ee1.0"}]},{"payload":{"datagram":[{"header":[{"specificationVersion":"1.3.0"},{"addressSource":[{"device":"d:_i:*device_id*"},{"entity":[1,1]},{"feature":11}]},{"addressDestination":[{"device":"d:_n:*device_id*"},{"entity":[2]},{"feature":9}]},{"msgCounter":74},{"cmdClassifier":"notify"}]},{"payload":[{"cmd":[[{"function":"measurementListData"},{"filter":[[{"cmdControl":[{"partial":[]}]}]]},{"measurementListData":[{"measurementData":[[{"measurementId":4},{"valueType":"value"},{"value":[{"number":0},{"scale":0}]},{"valueSource":"measuredValue"},{"valueState":"normal"}]]}]}]]}]}]}}]}
```

The identifiers in this case being the measurementId and the valueType, the first message only contains the measurementId while the second message contains both measerumentId and valueType. In the merge function the checked identifier for the first message is e.g. "4" while the checked identifier for the second message would be "4|value".
End result of this is that functions (such as in the eebus-go usecases) querying data receive multiple values for the same measurementId and have no way of identifying which of those should be correct.

This PR is in Draft state because I still wanted to test with the device producing this data how it responds to receiving a negative acknowledgement on the initial write with incomplete identifiers, and in case I might be missing something.