### PR TITLE
Improve binding and subscription manager

### DIFF
--- a/spine/binding_manager.go
+++ b/spine/binding_manager.go
@@ -178,7 +178,8 @@ func (c *BindingManager) RemoveBindingsForEntity(remoteEntity api.EntityRemoteIn
 
 	var newBindingEntries []*api.BindingEntry
 	for _, item := range c.bindingEntries {
-		if !reflect.DeepEqual(item.ClientFeature.Address().Entity, remoteEntity.Address().Entity) {
+		if !reflect.DeepEqual(item.ClientFeature.Address().Device, remoteEntity.Address().Device) ||
+			!reflect.DeepEqual(item.ClientFeature.Address().Entity, remoteEntity.Address().Entity) {
 			newBindingEntries = append(newBindingEntries, item)
 			continue
 		}

--- a/spine/binding_manager.go
+++ b/spine/binding_manager.go
@@ -94,20 +94,24 @@ func (c *BindingManager) RemoveBinding(data model.BindingManagementDeleteCallTyp
 	// b. The absence of "bindingDelete. serverAddress. device" SHALL be treated as if it was
 	//    present and set to the recipient's "device" address part.
 
-	var clientAddress model.FeatureAddressType
+	var clientAddress, serverAddress model.FeatureAddressType
 	util.DeepCopy(data.ClientAddress, &clientAddress)
 	if data.ClientAddress.Device == nil {
 		clientAddress.Device = remoteDevice.Address()
 	}
-
-	clientFeature := remoteDevice.FeatureByAddress(data.ClientAddress)
-	if clientFeature == nil {
-		return fmt.Errorf("client feature '%s' in remote device '%s' not found", data.ClientAddress, *remoteDevice.Address())
+	util.DeepCopy(data.ServerAddress, &serverAddress)
+	if data.ServerAddress.Device == nil {
+		serverAddress.Device = c.localDevice.Address()
 	}
 
-	serverFeature := c.localDevice.FeatureByAddress(data.ServerAddress)
+	clientFeature := remoteDevice.FeatureByAddress(&clientAddress)
+	if clientFeature == nil {
+		return fmt.Errorf("client feature '%s' in remote device '%s' not found", &clientAddress, *remoteDevice.Address())
+	}
+
+	serverFeature := c.localDevice.FeatureByAddress(&serverAddress)
 	if serverFeature == nil {
-		return fmt.Errorf("server feature '%s' in local device '%s' not found", data.ServerAddress, *c.localDevice.Address())
+		return fmt.Errorf("server feature '%s' in local device '%s' not found", &serverAddress, *c.localDevice.Address())
 	}
 
 	if err := c.checkRoleAndType(serverFeature, model.RoleTypeServer, serverFeature.Type()); err != nil {
@@ -115,17 +119,18 @@ func (c *BindingManager) RemoveBinding(data model.BindingManagementDeleteCallTyp
 	}
 
 	if !c.HasLocalFeatureRemoteBinding(serverFeature.Address(), clientFeature.Address()) {
-		return fmt.Errorf("the feature '%s' address has no binding", data.ClientAddress)
+		return fmt.Errorf("the feature '%s' address has no binding", &clientAddress)
 	}
 
 	c.mux.Lock()
 	defer c.mux.Unlock()
 
 	for _, item := range c.bindingEntries {
-		itemAddress := item.ClientFeature.Address()
+		itemClientAddress := item.ClientFeature.Address()
+		itemServerAddress := item.ServerFeature.Address()
 
-		if !reflect.DeepEqual(*itemAddress, clientAddress) &&
-			!reflect.DeepEqual(item.ServerFeature, serverFeature) {
+		if !reflect.DeepEqual(*itemClientAddress, clientAddress) ||
+			!reflect.DeepEqual(*itemServerAddress, serverAddress) {
 			newBindingEntries = append(newBindingEntries, item)
 		}
 	}

--- a/spine/binding_manager_test.go
+++ b/spine/binding_manager_test.go
@@ -43,17 +43,30 @@ func (suite *BindingManagerSuite) Test_Bindings() {
 	entity := NewEntityLocal(suite.localDevice, model.EntityTypeTypeCEM, []model.AddressEntityType{1}, time.Second*4)
 	suite.localDevice.AddEntity(entity)
 
-	localFeature := entity.GetOrAddFeature(model.FeatureTypeTypeDeviceDiagnosis, model.RoleTypeServer)
-	localClientFeature := entity.GetOrAddFeature(model.FeatureTypeTypeDeviceDiagnosis, model.RoleTypeClient)
+	localServerFeature := entity.GetOrAddFeature(model.FeatureTypeTypeDeviceDiagnosis, model.RoleTypeServer)
+	localServerFeature2 := entity.GetOrAddFeature(model.FeatureTypeTypeMeasurement, model.RoleTypeServer)
+	localServerFeature3 := entity.GetOrAddFeature(model.FeatureTypeTypeLoadControl, model.RoleTypeServer)
+	localClientFeature := entity.GetOrAddFeature(model.FeatureTypeTypeGeneric, model.RoleTypeClient)
+
+	remoteDeviceAddress := model.AddressDeviceType("remoteDevice")
+	suite.remoteDevice.UpdateDevice(
+		&model.NetworkManagementDeviceDescriptionDataType{
+			DeviceAddress: &model.DeviceAddressType{Device: &remoteDeviceAddress},
+		},
+	)
 
 	remoteEntity := NewEntityRemote(suite.remoteDevice, model.EntityTypeTypeEVSE, []model.AddressEntityType{1})
 
-	remoteFeature := NewFeatureRemote(remoteEntity.NextFeatureId(), remoteEntity, model.FeatureTypeTypeDeviceDiagnosis, model.RoleTypeClient)
-	remoteFeature.Address().Device = util.Ptr(model.AddressDeviceType("remoteDevice"))
-	remoteEntity.AddFeature(remoteFeature)
+	remoteClientFeature := NewFeatureRemote(remoteEntity.NextFeatureId(), remoteEntity, model.FeatureTypeTypeGeneric, model.RoleTypeClient)
+	remoteClientFeature.Address().Device = util.Ptr(remoteDeviceAddress)
+	remoteEntity.AddFeature(remoteClientFeature)
+
+	remoteClientFeature2 := NewFeatureRemote(remoteEntity.NextFeatureId(), remoteEntity, model.FeatureTypeTypeGeneric, model.RoleTypeClient)
+	remoteClientFeature2.Address().Device = util.Ptr(remoteDeviceAddress)
+	remoteEntity.AddFeature(remoteClientFeature2)
 
 	remoteServerFeature := NewFeatureRemote(remoteEntity.NextFeatureId(), remoteEntity, model.FeatureTypeTypeDeviceDiagnosis, model.RoleTypeServer)
-	remoteServerFeature.Address().Device = util.Ptr(model.AddressDeviceType("remoteDevice"))
+	remoteServerFeature.Address().Device = util.Ptr(remoteDeviceAddress)
 	remoteEntity.AddFeature(remoteServerFeature)
 
 	suite.remoteDevice.AddEntity(remoteEntity)
@@ -94,7 +107,7 @@ func (suite *BindingManagerSuite) Test_Bindings() {
 	err = bindingMgr.AddBinding(suite.remoteDevice, bindingRequest)
 	assert.NotNil(suite.T(), err)
 
-	bindingRequest.ServerAddress = localFeature.Address()
+	bindingRequest.ServerAddress = localServerFeature.Address()
 
 	err = bindingMgr.AddBinding(suite.remoteDevice, bindingRequest)
 	assert.NotNil(suite.T(), err)
@@ -104,7 +117,7 @@ func (suite *BindingManagerSuite) Test_Bindings() {
 	err = bindingMgr.AddBinding(suite.remoteDevice, bindingRequest)
 	assert.NotNil(suite.T(), err)
 
-	bindingRequest.ClientAddress = remoteFeature.Address()
+	bindingRequest.ClientAddress = remoteClientFeature.Address()
 
 	err = bindingMgr.AddBinding(suite.remoteDevice, bindingRequest)
 	assert.Nil(suite.T(), err)
@@ -126,23 +139,50 @@ func (suite *BindingManagerSuite) Test_Bindings() {
 	entries := bindingMgr.BindingsOnFeature(address)
 	assert.Equal(suite.T(), 0, len(entries))
 
-	address.Feature = localFeature.Address().Feature
+	address.Feature = localServerFeature.Address().Feature
 	entries = bindingMgr.BindingsOnFeature(address)
 	assert.Equal(suite.T(), 1, len(entries))
 
+	bindingRequest2 := model.BindingManagementRequestCallType{
+		ClientAddress:     remoteClientFeature.Address(),
+		ServerAddress:     localServerFeature2.Address(),
+		ServerFeatureType: util.Ptr(model.FeatureTypeTypeMeasurement),
+	}
+
+	err = bindingMgr.AddBinding(suite.remoteDevice, bindingRequest2)
+	assert.Nil(suite.T(), err)
+
+	address.Feature = localServerFeature2.Address().Feature
+	entries = bindingMgr.BindingsOnFeature(address)
+	assert.Equal(suite.T(), 1, len(entries))
+	entries = bindingMgr.Bindings(suite.remoteDevice)
+	assert.Equal(suite.T(), 2, len(entries))
+
+	bindingRequest2 = model.BindingManagementRequestCallType{
+		ClientAddress:     remoteClientFeature2.Address(),
+		ServerAddress:     localServerFeature3.Address(),
+		ServerFeatureType: util.Ptr(model.FeatureTypeTypeLoadControl),
+	}
+
+	err = bindingMgr.AddBinding(suite.remoteDevice, bindingRequest2)
+	assert.Nil(suite.T(), err)
+
+	address.Feature = localServerFeature3.Address().Feature
+	entries = bindingMgr.BindingsOnFeature(address)
+	assert.Equal(suite.T(), 1, len(entries))
+	entries = bindingMgr.Bindings(suite.remoteDevice)
+	assert.Equal(suite.T(), 3, len(entries))
+
 	bindingDelete := model.BindingManagementDeleteCallType{
 		ClientAddress: util.Ptr(model.FeatureAddressType{
-			Device:  util.Ptr(model.AddressDeviceType("dummy")),
 			Entity:  []model.AddressEntityType{1000},
 			Feature: util.Ptr(model.AddressFeatureType(1000)),
 		}),
 		ServerAddress: util.Ptr(model.FeatureAddressType{
-			Device:  util.Ptr(model.AddressDeviceType("dummy")),
 			Entity:  []model.AddressEntityType{1000},
 			Feature: util.Ptr(model.AddressFeatureType(1000)),
 		}),
 	}
-
 	err = bindingMgr.RemoveBinding(bindingDelete, suite.remoteDevice)
 	assert.NotNil(suite.T(), err)
 
@@ -159,18 +199,26 @@ func (suite *BindingManagerSuite) Test_Bindings() {
 	err = bindingMgr.RemoveBinding(bindingDelete, suite.remoteDevice)
 	assert.NotNil(suite.T(), err)
 
-	bindingDelete.ServerAddress = localFeature.Address()
+	bindingDelete.ServerAddress = localServerFeature.Address()
 
 	err = bindingMgr.RemoveBinding(bindingDelete, suite.remoteDevice)
 	assert.NotNil(suite.T(), err)
 
-	bindingDelete.ClientAddress = remoteFeature.Address()
+	bindingDelete.ClientAddress = remoteClientFeature2.Address()
+
+	err = bindingMgr.RemoveBinding(bindingDelete, suite.remoteDevice)
+	assert.NotNil(suite.T(), err)
+
+	subs = bindingMgr.Bindings(suite.remoteDevice)
+	assert.Equal(suite.T(), 3, len(subs))
+
+	bindingDelete.ClientAddress = remoteClientFeature.Address()
 
 	err = bindingMgr.RemoveBinding(bindingDelete, suite.remoteDevice)
 	assert.Nil(suite.T(), err)
 
 	subs = bindingMgr.Bindings(suite.remoteDevice)
-	assert.Equal(suite.T(), 0, len(subs))
+	assert.Equal(suite.T(), 2, len(subs))
 
 	err = bindingMgr.RemoveBinding(bindingDelete, suite.remoteDevice)
 	assert.NotNil(suite.T(), err)
@@ -179,7 +227,7 @@ func (suite *BindingManagerSuite) Test_Bindings() {
 	assert.Nil(suite.T(), err)
 
 	subs = bindingMgr.Bindings(suite.remoteDevice)
-	assert.Equal(suite.T(), 1, len(subs))
+	assert.Equal(suite.T(), 3, len(subs))
 
 	bindingMgr.RemoveBindingsForDevice(suite.remoteDevice)
 

--- a/spine/subscription_manager.go
+++ b/spine/subscription_manager.go
@@ -92,32 +92,35 @@ func (c *SubscriptionManager) RemoveSubscription(data model.SubscriptionManageme
 	// b. The absence of "subscriptionDelete. serverAddress. device" SHALL be treated as if it was
 	//    present and set to the recipient's "device" address part.
 
-	var clientAddress model.FeatureAddressType
+	var clientAddress, serverAddress model.FeatureAddressType
 	util.DeepCopy(data.ClientAddress, &clientAddress)
 	if data.ClientAddress.Device == nil {
 		clientAddress.Device = remoteDevice.Address()
 	}
-
-	clientFeature := remoteDevice.FeatureByAddress(data.ClientAddress)
-	if clientFeature == nil {
-		return fmt.Errorf("client feature '%s' in remote device '%s' not found", data.ClientAddress, *remoteDevice.Address())
+	util.DeepCopy(data.ServerAddress, &serverAddress)
+	if data.ServerAddress.Device == nil {
+		serverAddress.Device = c.localDevice.Address()
 	}
 
-	serverFeature := c.localDevice.FeatureByAddress(data.ServerAddress)
+	clientFeature := remoteDevice.FeatureByAddress(&clientAddress)
+	if clientFeature == nil {
+		return fmt.Errorf("client feature '%s' in remote device '%s' not found", &clientAddress, *remoteDevice.Address())
+	}
+
+	serverFeature := c.localDevice.FeatureByAddress(&serverAddress)
 	if serverFeature == nil {
-		return fmt.Errorf("server feature '%s' in local device '%s' not found", data.ServerAddress, *c.localDevice.Address())
+		return fmt.Errorf("server feature '%s' in local device '%s' not found", &serverAddress, *c.localDevice.Address())
 	}
 
 	c.mux.Lock()
 	defer c.mux.Unlock()
 
 	for _, item := range c.subscriptionEntries {
-		itemAddress := item.ClientFeature.Address()
+		itemClientAddress := item.ClientFeature.Address()
+		itemServerAddress := item.ServerFeature.Address()
 
-		if !reflect.DeepEqual(itemAddress.Device, clientAddress.Device) ||
-			!reflect.DeepEqual(itemAddress.Entity, clientAddress.Entity) ||
-			!reflect.DeepEqual(itemAddress.Feature, clientAddress.Feature) ||
-			!reflect.DeepEqual(item.ServerFeature, serverFeature) {
+		if !reflect.DeepEqual(*itemClientAddress, clientAddress) ||
+			!reflect.DeepEqual(*itemServerAddress, serverAddress) {
 			newSubscriptionEntries = append(newSubscriptionEntries, item)
 		}
 	}

--- a/spine/subscription_manager_test.go
+++ b/spine/subscription_manager_test.go
@@ -50,10 +50,23 @@ func (suite *SubscriptionManagerSuite) Test_Subscriptions() {
 	remoteEntity := NewEntityRemote(suite.remoteDevice, model.EntityTypeTypeEVSE, []model.AddressEntityType{1})
 	suite.remoteDevice.AddEntity(remoteEntity)
 
+	remoteDeviceAddress := model.AddressDeviceType("remoteDevice")
+	remoteDeviceAddress2 := model.AddressDeviceType("remoteDevice2")
+	suite.remoteDevice.UpdateDevice(
+		&model.NetworkManagementDeviceDescriptionDataType{
+			DeviceAddress: &model.DeviceAddressType{Device: &remoteDeviceAddress},
+		},
+	)
+	suite.remoteDevice2.UpdateDevice(
+		&model.NetworkManagementDeviceDescriptionDataType{
+			DeviceAddress: &model.DeviceAddressType{Device: &remoteDeviceAddress2},
+		},
+	)
+
 	remoteFeature := NewFeatureRemote(remoteEntity.NextFeatureId(), remoteEntity, model.FeatureTypeTypeDeviceDiagnosis, model.RoleTypeClient)
-	remoteFeature.Address().Device = util.Ptr(model.AddressDeviceType("remoteDevice"))
+	remoteFeature.Address().Device = &remoteDeviceAddress
 	remoteEntity.AddFeature(remoteFeature)
-	remoteEntity.Address().Device = util.Ptr(model.AddressDeviceType("remoteDevice"))
+	remoteEntity.Address().Device = &remoteDeviceAddress
 
 	subscrRequest := model.SubscriptionManagementRequestCallType{
 		ClientAddress:     remoteFeature.Address(),
@@ -65,9 +78,9 @@ func (suite *SubscriptionManagerSuite) Test_Subscriptions() {
 	suite.remoteDevice2.AddEntity(remoteEntity2)
 
 	remoteFeature2 := NewFeatureRemote(remoteEntity2.NextFeatureId(), remoteEntity2, model.FeatureTypeTypeDeviceDiagnosis, model.RoleTypeClient)
-	remoteFeature2.Address().Device = util.Ptr(model.AddressDeviceType("remoteDevice2"))
+	remoteFeature2.Address().Device = &remoteDeviceAddress2
 	remoteEntity2.AddFeature(remoteFeature2)
-	remoteEntity2.Address().Device = util.Ptr(model.AddressDeviceType("remoteDevice2"))
+	remoteEntity2.Address().Device = &remoteDeviceAddress2
 
 	subscrRequest2 := model.SubscriptionManagementRequestCallType{
 		ClientAddress:     remoteFeature2.Address(),
@@ -94,10 +107,15 @@ func (suite *SubscriptionManagerSuite) Test_Subscriptions() {
 	subs = subMgr.Subscriptions(suite.remoteDevice2)
 	assert.Equal(suite.T(), 1, len(subs))
 
+	var clientFeatureAddress, serverFeatureAddress model.FeatureAddressType
+	util.DeepCopy(remoteFeature.Address(), &clientFeatureAddress)
+	util.DeepCopy(localFeature.Address(), &serverFeatureAddress)
 	subscrDelete := model.SubscriptionManagementDeleteCallType{
-		ClientAddress: remoteFeature.Address(),
-		ServerAddress: localFeature.Address(),
+		ClientAddress: &clientFeatureAddress,
+		ServerAddress: &serverFeatureAddress,
 	}
+	subscrDelete.ClientAddress.Device = nil
+	subscrDelete.ServerAddress.Device = nil
 
 	err = subMgr.RemoveSubscription(subscrDelete, suite.remoteDevice)
 	assert.Nil(suite.T(), err)


### PR DESCRIPTION
- Added full support missing deviceAddress value on both manager implementations
- Added support for a single remote client registering bindings to multiple local servers
- Added checking device when removing an entity binding