### PR TITLE
Model references

### DIFF
--- a/model/alarm.go
+++ b/model/alarm.go
@@ -12,7 +12,7 @@ const (
 
 type AlarmDataType struct {
 	AlarmId          *AlarmIdType                `json:"alarmId,omitempty" eebus:"key,primarykey"`
-	ThresholdId      *ThresholdIdType            `json:"thresholdId,omitempty"`
+	ThresholdId      *ThresholdIdType            `json:"thresholdId,omitempty" eebus:"ref:ThresholdDescriptionDataType.ThresholdId"`
 	Timestamp        *AbsoluteOrRelativeTimeType `json:"timestamp,omitempty"`
 	AlarmType        *AlarmTypeType              `json:"alarmType,omitempty"`
 	MeasuredValue    *ScaledNumberType           `json:"measuredValue,omitempty"`

--- a/model/bill.go
+++ b/model/bill.go
@@ -88,7 +88,7 @@ type BillPositionElementsType struct {
 }
 
 type BillDataType struct {
-	BillId    *BillIdType        `json:"billId,omitempty" eebus:"key,primarykey"`
+	BillId    *BillIdType        `json:"billId,omitempty" eebus:"key,primarykey,ref:BillDescriptionDataType.BillId"`
 	BillType  *BillTypeType      `json:"billType,omitempty"`
 	ScopeType *ScopeTypeType     `json:"scopeType,omitempty"`
 	Total     *BillPositionType  `json:"total,omitempty"`
@@ -113,7 +113,7 @@ type BillListDataSelectorsType struct {
 }
 
 type BillConstraintsDataType struct {
-	BillId           *BillIdType            `json:"billId,omitempty" eebus:"key,primarykey"`
+	BillId           *BillIdType            `json:"billId,omitempty" eebus:"key,primarykey,ref:BillDescriptionDataType.BillId"`
 	PositionCountMin *BillPositionCountType `json:"positionCountMin,omitempty"`
 	PositionCountMax *BillPositionCountType `json:"positionCountMax,omitempty"`
 }

--- a/model/bill.go
+++ b/model/bill.go
@@ -137,7 +137,7 @@ type BillDescriptionDataType struct {
 	BillWriteable     *bool          `json:"billWriteable,omitempty"`
 	UpdateRequired    *bool          `json:"updateRequired,omitempty"`
 	SupportedBillType []BillTypeType `json:"supportedBillType,omitempty"`
-	SessionId         *SessionIdType `json:"sessionId,omitempty"`
+	SessionId         *SessionIdType `json:"sessionId,omitempty" eebus:"ref:SessionIdentificationDataType.SessionId"`
 }
 
 type BillDescriptionDataElementsType struct {

--- a/model/deviceconfiguration.go
+++ b/model/deviceconfiguration.go
@@ -134,7 +134,7 @@ type DeviceConfigurationKeyValueDescriptionListDataSelectorsType struct {
 }
 
 type DeviceConfigurationKeyValueConstraintsDataType struct {
-	KeyId         *DeviceConfigurationKeyIdType         `json:"keyId,omitempty" eebus:"key,primarykey"`
+	KeyId         *DeviceConfigurationKeyIdType         `json:"keyId,omitempty" eebus:"key,primarykey,ref:DeviceConfigurationKeyValueDescriptionDataType.KeyId"`
 	ValueRangeMin *DeviceConfigurationKeyValueValueType `json:"valueRangeMin,omitempty"`
 	ValueRangeMax *DeviceConfigurationKeyValueValueType `json:"valueRangeMax,omitempty"`
 	ValueStepSize *DeviceConfigurationKeyValueValueType `json:"valueStepSize,omitempty"`

--- a/model/deviceconfiguration.go
+++ b/model/deviceconfiguration.go
@@ -87,7 +87,7 @@ type DeviceConfigurationKeyValueValueElementsType struct {
 }
 
 type DeviceConfigurationKeyValueDataType struct {
-	KeyId             *DeviceConfigurationKeyIdType         `json:"keyId,omitempty" eebus:"key,primarykey"`
+	KeyId             *DeviceConfigurationKeyIdType         `json:"keyId,omitempty" eebus:"key,primarykey,ref:DeviceConfigurationKeyValueDescriptionDataType.KeyId"`
 	Value             *DeviceConfigurationKeyValueValueType `json:"value,omitempty"`
 	IsValueChangeable *bool                                 `json:"isValueChangeable,omitempty" eebus:"writecheck"`
 }

--- a/model/eebus_tags.go
+++ b/model/eebus_tags.go
@@ -15,6 +15,7 @@ const (
 	EEBusTagKey        EEBusTag = "key"
 	EEBusTagPrimaryKey EEBusTag = "primarykey"
 	EEBusTagWriteCheck EEBusTag = "writecheck"
+	EEBusTagRef        EEBusTag = "ref" // Foreign key reference: "ref:TargetType.TargetField"
 )
 
 type EEBusTagTypeType string

--- a/model/electricalconnection.go
+++ b/model/electricalconnection.go
@@ -88,7 +88,7 @@ const (
 type ElectricalConnectionParameterDescriptionDataType struct {
 	ElectricalConnectionId  *ElectricalConnectionIdType                `json:"electricalConnectionId,omitempty" eebus:"key,primarykey"`
 	ParameterId             *ElectricalConnectionParameterIdType       `json:"parameterId,omitempty" eebus:"key"`
-	MeasurementId           *MeasurementIdType                         `json:"measurementId,omitempty"`
+	MeasurementId           *MeasurementIdType                         `json:"measurementId,omitempty" eebus:"ref:MeasurementDescriptionDataType.MeasurementId"`
 	VoltageType             *ElectricalConnectionVoltageTypeType       `json:"voltageType,omitempty"`
 	AcMeasuredPhases        *ElectricalConnectionPhaseNameType         `json:"acMeasuredPhases,omitempty"`
 	AcMeasuredInReferenceTo *ElectricalConnectionPhaseNameType         `json:"acMeasuredInReferenceTo,omitempty"`
@@ -127,8 +127,8 @@ type ElectricalConnectionParameterDescriptionListDataSelectorsType struct {
 }
 
 type ElectricalConnectionPermittedValueSetDataType struct {
-	ElectricalConnectionId *ElectricalConnectionIdType          `json:"electricalConnectionId,omitempty" eebus:"key,primarykey"`
-	ParameterId            *ElectricalConnectionParameterIdType `json:"parameterId,omitempty" eebus:"key"`
+	ElectricalConnectionId *ElectricalConnectionIdType          `json:"electricalConnectionId,omitempty" eebus:"key,primarykey,ref:ElectricalConnectionParameterDescriptionDataType.ElectricalConnectionId"`
+	ParameterId            *ElectricalConnectionParameterIdType `json:"parameterId,omitempty" eebus:"key,ref:ElectricalConnectionParameterDescriptionDataType.ParameterId"`
 	PermittedValueSet      []ScaledNumberSetType                `json:"permittedValueSet,omitempty"`
 }
 
@@ -148,7 +148,7 @@ type ElectricalConnectionPermittedValueSetListDataSelectorsType struct {
 }
 
 type ElectricalConnectionStateDataType struct {
-	ElectricalConnectionId *ElectricalConnectionIdType `json:"electricalConnectionId,omitempty" eebus:"key"`
+	ElectricalConnectionId *ElectricalConnectionIdType `json:"electricalConnectionId,omitempty" eebus:"key,ref:ElectricalConnectionDescriptionDataType.ElectricalConnectionId"`
 	Timestamp              *AbsoluteOrRelativeTimeType `json:"timestamp,omitempty"`
 	CurrentEnergyMode      *EnergyModeType             `json:"currentEnergyMode,omitempty"`
 	ConsumptionTime        *DurationType               `json:"consumptionTime,omitempty"`
@@ -207,8 +207,8 @@ type ElectricalConnectionDescriptionListDataSelectorsType struct {
 }
 
 type ElectricalConnectionCharacteristicDataType struct {
-	ElectricalConnectionId *ElectricalConnectionIdType                    `json:"electricalConnectionId,omitempty" eebus:"key,primarykey"`
-	ParameterId            *ElectricalConnectionParameterIdType           `json:"parameterId,omitempty" eebus:"key"`
+	ElectricalConnectionId *ElectricalConnectionIdType                    `json:"electricalConnectionId,omitempty" eebus:"key,primarykey,ref:ElectricalConnectionParameterDescriptionDataType.ElectricalConnectionId"`
+	ParameterId            *ElectricalConnectionParameterIdType           `json:"parameterId,omitempty" eebus:"key,ref:ElectricalConnectionParameterDescriptionDataType.ParameterId"`
 	CharacteristicId       *ElectricalConnectionCharacteristicIdType      `json:"characteristicId,omitempty" eebus:"key"`
 	CharacteristicContext  *ElectricalConnectionCharacteristicContextType `json:"characteristicContext,omitempty"`
 	CharacteristicType     *ElectricalConnectionCharacteristicTypeType    `json:"characteristicType,omitempty"`

--- a/model/electricalconnection.go
+++ b/model/electricalconnection.go
@@ -86,7 +86,7 @@ const (
 )
 
 type ElectricalConnectionParameterDescriptionDataType struct {
-	ElectricalConnectionId  *ElectricalConnectionIdType                `json:"electricalConnectionId,omitempty" eebus:"key,primarykey"`
+	ElectricalConnectionId  *ElectricalConnectionIdType                `json:"electricalConnectionId,omitempty" eebus:"key,primarykey,ref:ElectricalConnectionDescriptionDataType.ElectricalConnectionId"`
 	ParameterId             *ElectricalConnectionParameterIdType       `json:"parameterId,omitempty" eebus:"key"`
 	MeasurementId           *MeasurementIdType                         `json:"measurementId,omitempty" eebus:"ref:MeasurementDescriptionDataType.MeasurementId"`
 	VoltageType             *ElectricalConnectionVoltageTypeType       `json:"voltageType,omitempty"`
@@ -127,7 +127,7 @@ type ElectricalConnectionParameterDescriptionListDataSelectorsType struct {
 }
 
 type ElectricalConnectionPermittedValueSetDataType struct {
-	ElectricalConnectionId *ElectricalConnectionIdType          `json:"electricalConnectionId,omitempty" eebus:"key,primarykey,ref:ElectricalConnectionParameterDescriptionDataType.ElectricalConnectionId"`
+	ElectricalConnectionId *ElectricalConnectionIdType          `json:"electricalConnectionId,omitempty" eebus:"key,primarykey,ref:ElectricalConnectionDescriptionDataType.ElectricalConnectionId"`
 	ParameterId            *ElectricalConnectionParameterIdType `json:"parameterId,omitempty" eebus:"key,ref:ElectricalConnectionParameterDescriptionDataType.ParameterId"`
 	PermittedValueSet      []ScaledNumberSetType                `json:"permittedValueSet,omitempty"`
 }

--- a/model/hvac.go
+++ b/model/hvac.go
@@ -49,7 +49,7 @@ const (
 )
 
 type HvacSystemFunctionDataType struct {
-	SystemFunctionId            *HvacSystemFunctionIdType `json:"systemFunctionId,omitempty" eebus:"key,primarykey"`
+	SystemFunctionId            *HvacSystemFunctionIdType `json:"systemFunctionId,omitempty" eebus:"key,primarykey,ref:HvacSystemFunctionDescriptionDataType.SystemFunctionId"`
 	CurrentOperationModeId      *HvacOperationModeIdType  `json:"currentOperationModeId,omitempty" eebus:"ref:HvacOperationModeDescriptionDataType.OperationModeId"`
 	IsOperationModeIdChangeable *bool                     `json:"isOperationModeIdChangeable,omitempty"`
 	CurrentSetpointId           *SetpointIdType           `json:"currentSetpointId,omitempty" eebus:"ref:SetpointDescriptionDataType.SetpointId"`
@@ -75,7 +75,7 @@ type HvacSystemFunctionListDataSelectorsType struct {
 }
 
 type HvacSystemFunctionOperationModeRelationDataType struct {
-	SystemFunctionId *HvacSystemFunctionIdType `json:"systemFunctionId,omitempty" eebus:"key,primarykey"`
+	SystemFunctionId *HvacSystemFunctionIdType `json:"systemFunctionId,omitempty" eebus:"key,primarykey,ref:HvacSystemFunctionDescriptionDataType.SystemFunctionId"`
 	OperationModeId  []HvacOperationModeIdType `json:"operationModeId,omitempty"`
 }
 
@@ -93,7 +93,7 @@ type HvacSystemFunctionOperationModeRelationListDataSelectorsType struct {
 }
 
 type HvacSystemFunctionSetpointRelationDataType struct {
-	SystemFunctionId *HvacSystemFunctionIdType `json:"systemFunctionId,omitempty" eebus:"key,primarykey"`
+	SystemFunctionId *HvacSystemFunctionIdType `json:"systemFunctionId,omitempty" eebus:"key,primarykey,ref:HvacSystemFunctionDescriptionDataType.SystemFunctionId"`
 	OperationModeId  *HvacOperationModeIdType  `json:"operationModeId,omitempty" eebus:"ref:HvacOperationModeDescriptionDataType.OperationModeId"`
 	SetpointId       []SetpointIdType          `json:"setpointId,omitempty"`
 }
@@ -114,7 +114,7 @@ type HvacSystemFunctionSetpointRelationListDataSelectorsType struct {
 }
 
 type HvacSystemFunctionPowerSequenceRelationDataType struct {
-	SystemFunctionId *HvacSystemFunctionIdType `json:"systemFunctionId,omitempty" eebus:"key,primarykey"`
+	SystemFunctionId *HvacSystemFunctionIdType `json:"systemFunctionId,omitempty" eebus:"key,primarykey,ref:HvacSystemFunctionDescriptionDataType.SystemFunctionId"`
 	SequenceId       []PowerSequenceIdType     `json:"sequenceId,omitempty"`
 }
 
@@ -176,7 +176,7 @@ type HvacOperationModeDescriptionListDataSelectorsType struct {
 }
 
 type HvacOverrunDataType struct {
-	OverrunId                 *HvacOverrunIdType     `json:"overrunId,omitempty" eebus:"key,primarykey"`
+	OverrunId                 *HvacOverrunIdType     `json:"overrunId,omitempty" eebus:"key,primarykey,ref:HvacOverrunDescriptionDataType.OverrunId"`
 	OverrunStatus             *HvacOverrunStatusType `json:"overrunStatus,omitempty"`
 	TimeTableId               *TimeTableIdType       `json:"timeTableId,omitempty" eebus:"ref:TimeTableDescriptionDataType.TimeTableId"`
 	IsOverrunStatusChangeable *bool                  `json:"isOverrunStatusChangeable,omitempty"`

--- a/model/hvac.go
+++ b/model/hvac.go
@@ -50,9 +50,9 @@ const (
 
 type HvacSystemFunctionDataType struct {
 	SystemFunctionId            *HvacSystemFunctionIdType `json:"systemFunctionId,omitempty" eebus:"key,primarykey"`
-	CurrentOperationModeId      *HvacOperationModeIdType  `json:"currentOperationModeId,omitempty"`
+	CurrentOperationModeId      *HvacOperationModeIdType  `json:"currentOperationModeId,omitempty" eebus:"ref:HvacOperationModeDescriptionDataType.OperationModeId"`
 	IsOperationModeIdChangeable *bool                     `json:"isOperationModeIdChangeable,omitempty"`
-	CurrentSetpointId           *SetpointIdType           `json:"currentSetpointId,omitempty"`
+	CurrentSetpointId           *SetpointIdType           `json:"currentSetpointId,omitempty" eebus:"ref:SetpointDescriptionDataType.SetpointId"`
 	IsSetpointIdChangeable      *bool                     `json:"isSetpointIdChangeable,omitempty"`
 	IsOverrunActive             *bool                     `json:"isOverrunActive,omitempty"`
 }
@@ -94,7 +94,7 @@ type HvacSystemFunctionOperationModeRelationListDataSelectorsType struct {
 
 type HvacSystemFunctionSetpointRelationDataType struct {
 	SystemFunctionId *HvacSystemFunctionIdType `json:"systemFunctionId,omitempty" eebus:"key,primarykey"`
-	OperationModeId  *HvacOperationModeIdType  `json:"operationModeId,omitempty"`
+	OperationModeId  *HvacOperationModeIdType  `json:"operationModeId,omitempty" eebus:"ref:HvacOperationModeDescriptionDataType.OperationModeId"`
 	SetpointId       []SetpointIdType          `json:"setpointId,omitempty"`
 }
 
@@ -178,7 +178,7 @@ type HvacOperationModeDescriptionListDataSelectorsType struct {
 type HvacOverrunDataType struct {
 	OverrunId                 *HvacOverrunIdType     `json:"overrunId,omitempty" eebus:"key,primarykey"`
 	OverrunStatus             *HvacOverrunStatusType `json:"overrunStatus,omitempty"`
-	TimeTableId               *TimeTableIdType       `json:"timeTableId,omitempty"`
+	TimeTableId               *TimeTableIdType       `json:"timeTableId,omitempty" eebus:"ref:TimeTableDescriptionDataType.TimeTableId"`
 	IsOverrunStatusChangeable *bool                  `json:"isOverrunStatusChangeable,omitempty"`
 }
 

--- a/model/identification.go
+++ b/model/identification.go
@@ -39,7 +39,7 @@ type IdentificationListDataSelectorsType struct {
 
 type SessionIdentificationDataType struct {
 	SessionId        *SessionIdType        `json:"sessionId,omitempty" eebus:"key,primarykey"`
-	IdentificationId *IdentificationIdType `json:"identificationId,omitempty"`
+	IdentificationId *IdentificationIdType `json:"identificationId,omitempty" eebus:"ref:IdentificationDataType.IdentificationId"`
 	IsLatestSession  *bool                 `json:"isLatestSession,omitempty"`
 	TimePeriod       *TimePeriodType       `json:"timePeriod,omitempty"`
 }

--- a/model/loadcontrol.go
+++ b/model/loadcontrol.go
@@ -77,7 +77,7 @@ type LoadControlEventListDataSelectorsType struct {
 
 type LoadControlStateDataType struct {
 	Timestamp                 *string                     `json:"timestamp"`
-	EventId                   *LoadControlEventIdType     `json:"eventId,omitempty" eebus:"key,primarykey"`
+	EventId                   *LoadControlEventIdType     `json:"eventId,omitempty" eebus:"key,primarykey,ref:LoadControlEventDataType.EventId"`
 	EventStateConsume         *LoadControlEventStateType  `json:"eventStateConsume"`
 	AppliedEventActionConsume *LoadControlEventActionType `json:"appliedEventActionConsume"`
 	EventStateProduce         *LoadControlEventStateType  `json:"eventStateProduce"`
@@ -103,7 +103,7 @@ type LoadControlStateListDataSelectorsType struct {
 }
 
 type LoadControlLimitDataType struct {
-	LimitId           *LoadControlLimitIdType `json:"limitId,omitempty" eebus:"key,primarykey"`
+	LimitId           *LoadControlLimitIdType `json:"limitId,omitempty" eebus:"key,primarykey,ref:LoadControlLimitDescriptionDataType.LimitId"`
 	IsLimitChangeable *bool                   `json:"isLimitChangeable,omitempty" eebus:"writecheck"`
 	IsLimitActive     *bool                   `json:"isLimitActive,omitempty"`
 	TimePeriod        *TimePeriodType         `json:"timePeriod,omitempty"`
@@ -127,7 +127,7 @@ type LoadControlLimitListDataSelectorsType struct {
 }
 
 type LoadControlLimitConstraintsDataType struct {
-	LimitId       *LoadControlLimitIdType `json:"limitId,omitempty" eebus:"key,primarykey"`
+	LimitId       *LoadControlLimitIdType `json:"limitId,omitempty" eebus:"key,primarykey,ref:LoadControlLimitDescriptionDataType.LimitId"`
 	ValueRangeMin *ScaledNumberType       `json:"valueRangeMin,omitempty"`
 	ValueRangeMax *ScaledNumberType       `json:"valueRangeMax,omitempty"`
 	ValueStepSize *ScaledNumberType       `json:"valueStepSize,omitempty"`
@@ -153,7 +153,7 @@ type LoadControlLimitDescriptionDataType struct {
 	LimitType      *LoadControlLimitTypeType `json:"limitType,omitempty"`
 	LimitCategory  *LoadControlCategoryType  `json:"limitCategory,omitempty"`
 	LimitDirection *EnergyDirectionType      `json:"limitDirection,omitempty"`
-	MeasurementId  *MeasurementIdType        `json:"measurementId,omitempty"`
+	MeasurementId  *MeasurementIdType        `json:"measurementId,omitempty" eebus:"ref:MeasurementDescriptionDataType.MeasurementId"`
 	Unit           *UnitOfMeasurementType    `json:"unit,omitempty"`
 	ScopeType      *ScopeTypeType            `json:"scopeType,omitempty"`
 	Label          *LabelType                `json:"label,omitempty"`

--- a/model/measurement.go
+++ b/model/measurement.go
@@ -84,7 +84,7 @@ const (
 )
 
 type MeasurementDataType struct {
-	MeasurementId    *MeasurementIdType            `json:"measurementId,omitempty" eebus:"key,primarykey"`
+	MeasurementId    *MeasurementIdType            `json:"measurementId,omitempty" eebus:"key,primarykey,ref:MeasurementDescriptionDataType.MeasurementId"`
 	ValueType        *MeasurementValueTypeType     `json:"valueType,omitempty" eebus:"key"`
 	Timestamp        *AbsoluteOrRelativeTimeType   `json:"timestamp,omitempty"`
 	Value            *ScaledNumberType             `json:"value,omitempty"`
@@ -116,7 +116,7 @@ type MeasurementListDataSelectorsType struct {
 }
 
 type MeasurementSeriesDataType struct {
-	MeasurementId    *MeasurementIdType            `json:"measurementId,omitempty" eebus:"key,primarykey"`
+	MeasurementId    *MeasurementIdType            `json:"measurementId,omitempty" eebus:"key,primarykey,ref:MeasurementDescriptionDataType.MeasurementId"`
 	ValueType        *MeasurementValueTypeType     `json:"valueType,omitempty" eebus:"key"`
 	Timestamp        *AbsoluteOrRelativeTimeType   `json:"timestamp,omitempty"`
 	Value            *ScaledNumberType             `json:"value,omitempty"`
@@ -148,7 +148,7 @@ type MeasurementSeriesListDataSelectorsType struct {
 }
 
 type MeasurementConstraintsDataType struct {
-	MeasurementId *MeasurementIdType `json:"measurementId,omitempty" eebus:"key,primarykey"`
+	MeasurementId *MeasurementIdType `json:"measurementId,omitempty" eebus:"key,primarykey,ref:MeasurementDescriptionDataType.MeasurementId"`
 	ValueRangeMin *ScaledNumberType  `json:"valueRangeMin,omitempty"`
 	ValueRangeMax *ScaledNumberType  `json:"valueRangeMax,omitempty"`
 	ValueStepSize *ScaledNumberType  `json:"valueStepSize,omitempty"`
@@ -203,7 +203,7 @@ type MeasurementDescriptionListDataSelectorsType struct {
 }
 
 type MeasurementThresholdRelationDataType struct {
-	MeasurementId *MeasurementIdType `json:"measurementId,omitempty" eebus:"key,primarykey"`
+	MeasurementId *MeasurementIdType `json:"measurementId,omitempty" eebus:"key,primarykey,ref:MeasurementDescriptionDataType.MeasurementId"`
 	ThresholdId   []ThresholdIdType  `json:"thresholdId,omitempty"`
 }
 

--- a/model/operatingconstraints.go
+++ b/model/operatingconstraints.go
@@ -1,7 +1,7 @@
 package model
 
 type OperatingConstraintsInterruptDataType struct {
-	SequenceId                  *PowerSequenceIdType `json:"sequenceId,omitempty" eebus:"key,primarykey"`
+	SequenceId                  *PowerSequenceIdType `json:"sequenceId,omitempty" eebus:"key,primarykey,ref:PowerSequenceDescriptionDataType.SequenceId"`
 	IsPausable                  *bool                `json:"isPausable,omitempty"`
 	IsStoppable                 *bool                `json:"isStoppable,omitempty"`
 	NotInterruptibleAtHighPower *bool                `json:"notInterruptibleAtHighPower,omitempty"`
@@ -25,7 +25,7 @@ type OperatingConstraintsInterruptListDataSelectorsType struct {
 }
 
 type OperatingConstraintsDurationDataType struct {
-	SequenceId           *PowerSequenceIdType `json:"sequenceId,omitempty" eebus:"key,primarykey"`
+	SequenceId           *PowerSequenceIdType `json:"sequenceId,omitempty" eebus:"key,primarykey,ref:PowerSequenceDescriptionDataType.SequenceId"`
 	ActiveDurationMin    *DurationType        `json:"activeDurationMin,omitempty"`
 	ActiveDurationMax    *DurationType        `json:"activeDurationMax,omitempty"`
 	PauseDurationMin     *DurationType        `json:"pauseDurationMin,omitempty"`
@@ -53,7 +53,7 @@ type OperatingConstraintsDurationListDataSelectorsType struct {
 }
 
 type OperatingConstraintsPowerDescriptionDataType struct {
-	SequenceId              *PowerSequenceIdType   `json:"sequenceId,omitempty" eebus:"key,primarykey"`
+	SequenceId              *PowerSequenceIdType   `json:"sequenceId,omitempty" eebus:"key,primarykey,ref:PowerSequenceDescriptionDataType.SequenceId"`
 	PositiveEnergyDirection *EnergyDirectionType   `json:"positiveEnergyDirection,omitempty"`
 	PowerUnit               *UnitOfMeasurementType `json:"powerUnit,omitempty"`
 	EnergyUnit              *UnitOfMeasurementType `json:"energyUnit,omitempty"`
@@ -77,7 +77,7 @@ type OperatingConstraintsPowerDescriptionListDataSelectorsType struct {
 }
 
 type OperatingConstraintsPowerRangeDataType struct {
-	SequenceId *PowerSequenceIdType `json:"sequenceId,omitempty" eebus:"key,primarykey"`
+	SequenceId *PowerSequenceIdType `json:"sequenceId,omitempty" eebus:"key,primarykey,ref:PowerSequenceDescriptionDataType.SequenceId"`
 	PowerMin   *ScaledNumberType    `json:"powerMin,omitempty"`
 	PowerMax   *ScaledNumberType    `json:"powerMax,omitempty"`
 	EnergyMin  *ScaledNumberType    `json:"energyMin,omitempty"`
@@ -101,7 +101,7 @@ type OperatingConstraintsPowerRangeListDataSelectorsType struct {
 }
 
 type OperatingConstraintsPowerLevelDataType struct {
-	SequenceId *PowerSequenceIdType `json:"sequenceId,omitempty" eebus:"key,primarykey"`
+	SequenceId *PowerSequenceIdType `json:"sequenceId,omitempty" eebus:"key,primarykey,ref:PowerSequenceDescriptionDataType.SequenceId"`
 	Power      *ScaledNumberType    `json:"power,omitempty"`
 }
 
@@ -119,7 +119,7 @@ type OperatingConstraintsPowerLevelListDataSelectorsType struct {
 }
 
 type OperatingConstraintsResumeImplicationDataType struct {
-	SequenceId            *PowerSequenceIdType   `json:"sequenceId,omitempty" eebus:"key,primarykey"`
+	SequenceId            *PowerSequenceIdType   `json:"sequenceId,omitempty" eebus:"key,primarykey,ref:PowerSequenceDescriptionDataType.SequenceId"`
 	ResumeEnergyEstimated *ScaledNumberType      `json:"resumeEnergyEstimated,omitempty"`
 	EnergyUnit            *UnitOfMeasurementType `json:"energyUnit,omitempty"`
 	ResumeCostEstimated   *ScaledNumberType      `json:"resumeCostEstimated,omitempty"`

--- a/model/powersequences.go
+++ b/model/powersequences.go
@@ -45,7 +45,7 @@ const (
 )
 
 type PowerTimeSlotScheduleDataType struct {
-	SequenceId          *PowerSequenceIdType     `json:"sequenceId,omitempty" eebus:"key,primarykey"`
+	SequenceId          *PowerSequenceIdType     `json:"sequenceId,omitempty" eebus:"key,primarykey,ref:PowerSequenceDescriptionDataType.SequenceId"`
 	SlotNumber          *PowerTimeSlotNumberType `json:"slotNumber,omitempty"`
 	TimePeriod          *TimePeriodType          `json:"timePeriod,omitempty"`
 	DefaultDuration     *DurationType            `json:"defaultDuration,omitempty"`
@@ -74,7 +74,7 @@ type PowerTimeSlotScheduleListDataSelectorsType struct {
 }
 
 type PowerTimeSlotValueDataType struct {
-	SequenceId *PowerSequenceIdType        `json:"sequenceId,omitempty" eebus:"key,primarykey"`
+	SequenceId *PowerSequenceIdType        `json:"sequenceId,omitempty" eebus:"key,primarykey,ref:PowerSequenceDescriptionDataType.SequenceId"`
 	SlotNumber *PowerTimeSlotNumberType    `json:"slotNumber,omitempty"`
 	ValueType  *PowerTimeSlotValueTypeType `json:"valueType,omitempty"`
 	Value      *ScaledNumberType           `json:"value,omitempty"`
@@ -98,7 +98,7 @@ type PowerTimeSlotValueListDataSelectorsType struct {
 }
 
 type PowerTimeSlotScheduleConstraintsDataType struct {
-	SequenceId        *PowerSequenceIdType        `json:"sequenceId,omitempty" eebus:"key,primarykey"`
+	SequenceId        *PowerSequenceIdType        `json:"sequenceId,omitempty" eebus:"key,primarykey,ref:PowerSequenceDescriptionDataType.SequenceId"`
 	SlotNumber        *PowerTimeSlotNumberType    `json:"slotNumber,omitempty"`
 	EarliestStartTime *AbsoluteOrRelativeTimeType `json:"earliestStartTime,omitempty"`
 	LatestEndTime     *AbsoluteOrRelativeTimeType `json:"latestEndTime,omitempty"`
@@ -178,7 +178,7 @@ type PowerSequenceDescriptionListDataSelectorsType struct {
 }
 
 type PowerSequenceStateDataType struct {
-	SequenceId                 *PowerSequenceIdType     `json:"sequenceId,omitempty" eebus:"key,primarykey"`
+	SequenceId                 *PowerSequenceIdType     `json:"sequenceId,omitempty" eebus:"key,primarykey,ref:PowerSequenceDescriptionDataType.SequenceId"`
 	State                      *PowerSequenceStateType  `json:"state,omitempty"`
 	ActiveSlotNumber           *PowerTimeSlotNumberType `json:"activeSlotNumber,omitempty"`
 	ElapsedSlotTime            *DurationType            `json:"elapsedSlotTime,omitempty"`
@@ -208,7 +208,7 @@ type PowerSequenceStateListDataSelectorsType struct {
 }
 
 type PowerSequenceScheduleDataType struct {
-	SequenceId *PowerSequenceIdType        `json:"sequenceId,omitempty" eebus:"key,primarykey"`
+	SequenceId *PowerSequenceIdType        `json:"sequenceId,omitempty" eebus:"key,primarykey,ref:PowerSequenceDescriptionDataType.SequenceId"`
 	StartTime  *AbsoluteOrRelativeTimeType `json:"startTime,omitempty"`
 	EndTime    *AbsoluteOrRelativeTimeType `json:"endTime,omitempty"`
 }
@@ -228,7 +228,7 @@ type PowerSequenceScheduleListDataSelectorsType struct {
 }
 
 type PowerSequenceScheduleConstraintsDataType struct {
-	SequenceId        *PowerSequenceIdType        `json:"sequenceId,omitempty" eebus:"key,primarykey"`
+	SequenceId        *PowerSequenceIdType        `json:"sequenceId,omitempty" eebus:"key,primarykey,ref:PowerSequenceDescriptionDataType.SequenceId"`
 	EarliestStartTime *AbsoluteOrRelativeTimeType `json:"earliestStartTime,omitempty"`
 	LatestStartTime   *AbsoluteOrRelativeTimeType `json:"latestStartTime,omitempty"`
 	EarliestEndTime   *AbsoluteOrRelativeTimeType `json:"earliestEndTime,omitempty"`
@@ -254,7 +254,7 @@ type PowerSequenceScheduleConstraintsListDataSelectorsType struct {
 }
 
 type PowerSequencePriceDataType struct {
-	SequenceId         *PowerSequenceIdType        `json:"sequenceId,omitempty" eebus:"key,primarykey"`
+	SequenceId         *PowerSequenceIdType        `json:"sequenceId,omitempty" eebus:"key,primarykey,ref:PowerSequenceDescriptionDataType.SequenceId"`
 	PotentialStartTime *AbsoluteOrRelativeTimeType `json:"potentialStartTime,omitempty"`
 	Price              *ScaledNumberType           `json:"price,omitempty"`
 	Currency           *CurrencyType               `json:"currency,omitempty"`
@@ -277,7 +277,7 @@ type PowerSequencePriceListDataSelectorsType struct {
 }
 
 type PowerSequenceSchedulePreferenceDataType struct {
-	SequenceId *PowerSequenceIdType `json:"sequenceId,omitempty" eebus:"key,primarykey"`
+	SequenceId *PowerSequenceIdType `json:"sequenceId,omitempty" eebus:"key,primarykey,ref:PowerSequenceDescriptionDataType.SequenceId"`
 	Greenest   *bool                `json:"greenest,omitempty"`
 	Cheapest   *bool                `json:"cheapest,omitempty"`
 }

--- a/model/relationship_comprehensive_test.go
+++ b/model/relationship_comprehensive_test.go
@@ -97,9 +97,24 @@ func TestNewRelationships_TierBoundaryData(t *testing.T) {
 	data := TierBoundaryDataType{}
 	rels := GetRelationships(data)
 
-	assert.Len(t, rels, 1)
-	assert.Equal(t, "TimeTableId", rels[0].FieldName)
-	assert.Equal(t, "TimeTableDescriptionDataType", rels[0].TargetType)
+	assert.Len(t, rels, 2)
+
+	// Check both relationships exist
+	var foundBoundaryId, foundTimeTableId bool
+	for _, rel := range rels {
+		if rel.FieldName == "BoundaryId" {
+			assert.Equal(t, "TierBoundaryDescriptionDataType", rel.TargetType)
+			assert.True(t, rel.IsComposite, "BoundaryId is the primary key")
+			foundBoundaryId = true
+		}
+		if rel.FieldName == "TimeTableId" {
+			assert.Equal(t, "TimeTableDescriptionDataType", rel.TargetType)
+			assert.False(t, rel.IsComposite, "TimeTableId is not part of the primary key")
+			foundTimeTableId = true
+		}
+	}
+	assert.True(t, foundBoundaryId, "Should have BoundaryId relationship")
+	assert.True(t, foundTimeTableId, "Should have TimeTableId relationship")
 }
 
 // TestNewRelationships_SessionIdentification tests SessionIdentification relationships
@@ -117,11 +132,16 @@ func TestNewRelationships_HvacSystemFunction(t *testing.T) {
 	data := HvacSystemFunctionDataType{}
 	rels := GetRelationships(data)
 
-	assert.Len(t, rels, 2)
+	assert.Len(t, rels, 3)
 
-	// Check both relationships exist
-	var foundOperationMode, foundSetpoint bool
+	// Check all relationships exist
+	var foundSystemFunctionId, foundOperationMode, foundSetpoint bool
 	for _, rel := range rels {
+		if rel.FieldName == "SystemFunctionId" {
+			assert.Equal(t, "HvacSystemFunctionDescriptionDataType", rel.TargetType)
+			assert.True(t, rel.IsComposite, "SystemFunctionId is the primary key")
+			foundSystemFunctionId = true
+		}
 		if rel.FieldName == "CurrentOperationModeId" {
 			assert.Equal(t, "HvacOperationModeDescriptionDataType", rel.TargetType)
 			foundOperationMode = true
@@ -131,6 +151,7 @@ func TestNewRelationships_HvacSystemFunction(t *testing.T) {
 			foundSetpoint = true
 		}
 	}
+	assert.True(t, foundSystemFunctionId, "Should have SystemFunctionId relationship")
 	assert.True(t, foundOperationMode, "Should have CurrentOperationModeId relationship")
 	assert.True(t, foundSetpoint, "Should have CurrentSetpointId relationship")
 }
@@ -140,9 +161,24 @@ func TestNewRelationships_SupplyCondition(t *testing.T) {
 	data := SupplyConditionDataType{}
 	rels := GetRelationships(data)
 
-	assert.Len(t, rels, 1)
-	assert.Equal(t, "ThresholdId", rels[0].FieldName)
-	assert.Equal(t, "ThresholdDescriptionDataType", rels[0].TargetType)
+	assert.Len(t, rels, 2)
+
+	// Check both relationships exist
+	var foundConditionId, foundThresholdId bool
+	for _, rel := range rels {
+		if rel.FieldName == "ConditionId" {
+			assert.Equal(t, "SupplyConditionDescriptionDataType", rel.TargetType)
+			assert.True(t, rel.IsComposite, "ConditionId is the primary key")
+			foundConditionId = true
+		}
+		if rel.FieldName == "ThresholdId" {
+			assert.Equal(t, "ThresholdDescriptionDataType", rel.TargetType)
+			assert.False(t, rel.IsComposite, "ThresholdId is not part of the primary key")
+			foundThresholdId = true
+		}
+	}
+	assert.True(t, foundConditionId, "Should have ConditionId relationship")
+	assert.True(t, foundThresholdId, "Should have ThresholdId relationship")
 }
 
 // TestNewRelationships_TaskManagement tests TaskManagement cross-feature relationships

--- a/model/relationship_comprehensive_test.go
+++ b/model/relationship_comprehensive_test.go
@@ -1,0 +1,170 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestNewRelationships_TimeSeries tests TimeSeries relationships
+func TestNewRelationships_TimeSeries(t *testing.T) {
+	data := TimeSeriesDescriptionDataType{}
+	rels := GetRelationships(data)
+
+	assert.Len(t, rels, 1)
+	assert.Equal(t, "MeasurementId", rels[0].FieldName)
+	assert.Equal(t, "MeasurementDescriptionDataType", rels[0].TargetType)
+}
+
+// TestNewRelationships_LoadControlState tests LoadControl state relationships
+func TestNewRelationships_LoadControlState(t *testing.T) {
+	data := LoadControlStateDataType{}
+	rels := GetRelationships(data)
+
+	assert.Len(t, rels, 1)
+	assert.Equal(t, "EventId", rels[0].FieldName)
+	assert.Equal(t, "LoadControlEventDataType", rels[0].TargetType)
+	assert.True(t, rels[0].IsComposite)
+}
+
+// TestNewRelationships_LoadControlConstraints tests LoadControl constraints relationships
+func TestNewRelationships_LoadControlConstraints(t *testing.T) {
+	data := LoadControlLimitConstraintsDataType{}
+	rels := GetRelationships(data)
+
+	assert.Len(t, rels, 1)
+	assert.Equal(t, "LimitId", rels[0].FieldName)
+	assert.Equal(t, "LoadControlLimitDescriptionDataType", rels[0].TargetType)
+	assert.True(t, rels[0].IsComposite)
+}
+
+// TestNewRelationships_Alarm tests Alarm relationships
+func TestNewRelationships_Alarm(t *testing.T) {
+	data := AlarmDataType{}
+	rels := GetRelationships(data)
+
+	assert.Len(t, rels, 1)
+	assert.Equal(t, "ThresholdId", rels[0].FieldName)
+	assert.Equal(t, "ThresholdDescriptionDataType", rels[0].TargetType)
+}
+
+// TestNewRelationships_Bill tests Bill relationships
+func TestNewRelationships_Bill(t *testing.T) {
+	data := BillDescriptionDataType{}
+	rels := GetRelationships(data)
+
+	assert.Len(t, rels, 1)
+	assert.Equal(t, "SessionId", rels[0].FieldName)
+	assert.Equal(t, "SessionIdentificationDataType", rels[0].TargetType)
+}
+
+// TestNewRelationships_TariffDescription tests Tariff description relationships
+func TestNewRelationships_TariffDescription(t *testing.T) {
+	data := TariffDescriptionDataType{}
+	rels := GetRelationships(data)
+
+	assert.Len(t, rels, 1)
+	assert.Equal(t, "MeasurementId", rels[0].FieldName)
+	assert.Equal(t, "MeasurementDescriptionDataType", rels[0].TargetType)
+}
+
+// TestNewRelationships_TierBoundaryDescription tests complex multi-reference relationships
+func TestNewRelationships_TierBoundaryDescription(t *testing.T) {
+	data := TierBoundaryDescriptionDataType{}
+	rels := GetRelationships(data)
+
+	// Should have 3 TierId references
+	assert.Len(t, rels, 3)
+
+	// All should reference TierDescriptionDataType.TierId
+	for _, rel := range rels {
+		assert.Equal(t, "TierDescriptionDataType", rel.TargetType)
+		assert.Equal(t, "TierId", rel.TargetField)
+	}
+
+	// Check specific field names
+	fieldNames := []string{}
+	for _, rel := range rels {
+		fieldNames = append(fieldNames, rel.FieldName)
+	}
+	assert.Contains(t, fieldNames, "ValidForTierId")
+	assert.Contains(t, fieldNames, "SwitchToTierIdWhenLower")
+	assert.Contains(t, fieldNames, "SwitchToTierIdWhenHigher")
+}
+
+// TestNewRelationships_TierBoundaryData tests TierBoundary data relationships
+func TestNewRelationships_TierBoundaryData(t *testing.T) {
+	data := TierBoundaryDataType{}
+	rels := GetRelationships(data)
+
+	assert.Len(t, rels, 1)
+	assert.Equal(t, "TimeTableId", rels[0].FieldName)
+	assert.Equal(t, "TimeTableDescriptionDataType", rels[0].TargetType)
+}
+
+// TestNewRelationships_SessionIdentification tests SessionIdentification relationships
+func TestNewRelationships_SessionIdentification(t *testing.T) {
+	data := SessionIdentificationDataType{}
+	rels := GetRelationships(data)
+
+	assert.Len(t, rels, 1)
+	assert.Equal(t, "IdentificationId", rels[0].FieldName)
+	assert.Equal(t, "IdentificationDataType", rels[0].TargetType)
+}
+
+// TestNewRelationships_HvacSystemFunction tests HVAC relationships
+func TestNewRelationships_HvacSystemFunction(t *testing.T) {
+	data := HvacSystemFunctionDataType{}
+	rels := GetRelationships(data)
+
+	assert.Len(t, rels, 2)
+
+	// Check both relationships exist
+	var foundOperationMode, foundSetpoint bool
+	for _, rel := range rels {
+		if rel.FieldName == "CurrentOperationModeId" {
+			assert.Equal(t, "HvacOperationModeDescriptionDataType", rel.TargetType)
+			foundOperationMode = true
+		}
+		if rel.FieldName == "CurrentSetpointId" {
+			assert.Equal(t, "SetpointDescriptionDataType", rel.TargetType)
+			foundSetpoint = true
+		}
+	}
+	assert.True(t, foundOperationMode, "Should have CurrentOperationModeId relationship")
+	assert.True(t, foundSetpoint, "Should have CurrentSetpointId relationship")
+}
+
+// TestNewRelationships_SupplyCondition tests SupplyCondition relationships
+func TestNewRelationships_SupplyCondition(t *testing.T) {
+	data := SupplyConditionDataType{}
+	rels := GetRelationships(data)
+
+	assert.Len(t, rels, 1)
+	assert.Equal(t, "ThresholdId", rels[0].FieldName)
+	assert.Equal(t, "ThresholdDescriptionDataType", rels[0].TargetType)
+}
+
+// TestNewRelationships_TaskManagement tests TaskManagement cross-feature relationships
+func TestNewRelationships_TaskManagement(t *testing.T) {
+	// Test HVAC-related task
+	hvacData := TaskManagementHvacRelatedType{}
+	hvacRels := GetRelationships(hvacData)
+	assert.Len(t, hvacRels, 1)
+	assert.Equal(t, "OverrunId", hvacRels[0].FieldName)
+	assert.Equal(t, "HvacOverrunDescriptionDataType", hvacRels[0].TargetType)
+
+	// Test LoadControl-related task
+	lcData := TaskManagementLoadControlReleatedType{}
+	lcRels := GetRelationships(lcData)
+	assert.Len(t, lcRels, 1)
+	assert.Equal(t, "EventId", lcRels[0].FieldName)
+	assert.Equal(t, "LoadControlEventDataType", lcRels[0].TargetType)
+
+	// Test PowerSequences-related task
+	psData := TaskManagementPowerSequencesRelatedType{}
+	psRels := GetRelationships(psData)
+	assert.Len(t, psRels, 1)
+	assert.Equal(t, "SequenceId", psRels[0].FieldName)
+	assert.Equal(t, "PowerSequenceDescriptionDataType", psRels[0].TargetType)
+}

--- a/model/relationship_helper.go
+++ b/model/relationship_helper.go
@@ -1,0 +1,98 @@
+package model
+
+import (
+	"reflect"
+	"strings"
+)
+
+// RelationshipInfo describes a foreign key relationship from one type to another
+type RelationshipInfo struct {
+	// FieldName is the local field that contains the foreign key
+	FieldName string
+
+	// TargetType is the name of the target type being referenced
+	TargetType string
+
+	// TargetField is the field name in the target type that this foreign key references
+	TargetField string
+
+	// IsComposite indicates if this is part of a composite foreign key
+	IsComposite bool
+}
+
+// GetRelationships extracts all relationship metadata from a type's struct tags
+// It looks for fields with eebus:"ref:TargetType.TargetField" tags
+//
+// Example usage:
+//
+//	type LoadControlLimitDescriptionDataType struct {
+//	    LimitId       *LoadControlLimitIdType `eebus:"key,primarykey"`
+//	    MeasurementId *MeasurementIdType      `eebus:"ref:MeasurementDescriptionDataType.MeasurementId"`
+//	}
+//
+//	rels := GetRelationships(LoadControlLimitDescriptionDataType{})
+//	// Returns: [{FieldName: "MeasurementId", TargetType: "MeasurementDescriptionDataType", TargetField: "MeasurementId"}]
+func GetRelationships(dataType any) []RelationshipInfo {
+	var result []RelationshipInfo
+
+	t := reflect.TypeOf(dataType)
+	if t == nil {
+		return result
+	}
+
+	// Handle pointer types
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	if t.Kind() != reflect.Struct {
+		return result
+	}
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		tags := EEBusTags(field)
+
+		// Check for ref tag
+		refValue, hasRef := tags[EEBusTagRef]
+		if !hasRef || refValue == "" || refValue == "true" {
+			continue
+		}
+
+		// Parse ref value: "TargetType.TargetField"
+		parts := strings.Split(refValue, ".")
+		if len(parts) != 2 {
+			continue
+		}
+
+		// Check if this is part of a composite key
+		_, hasKey := tags[EEBusTagKey]
+		_, hasPrimaryKey := tags[EEBusTagPrimaryKey]
+		isComposite := hasKey || hasPrimaryKey
+
+		result = append(result, RelationshipInfo{
+			FieldName:   field.Name,
+			TargetType:  parts[0],
+			TargetField: parts[1],
+			IsComposite: isComposite,
+		})
+	}
+
+	return result
+}
+
+// GetRelationshipsByFieldName returns relationship info for a specific field
+func GetRelationshipsByFieldName(dataType any, fieldName string) *RelationshipInfo {
+	rels := GetRelationships(dataType)
+	for _, rel := range rels {
+		if rel.FieldName == fieldName {
+			return &rel
+		}
+	}
+	return nil
+}
+
+// HasRelationships returns true if the type has any relationship metadata
+func HasRelationships(dataType any) bool {
+	return len(GetRelationships(dataType)) > 0
+}

--- a/model/relationship_helper_test.go
+++ b/model/relationship_helper_test.go
@@ -1,0 +1,134 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetRelationships_LoadControlLimitDescription(t *testing.T) {
+	data := LoadControlLimitDescriptionDataType{}
+	rels := GetRelationships(data)
+
+	assert.Len(t, rels, 1, "LoadControlLimitDescriptionDataType should have 1 relationship")
+	assert.Equal(t, "MeasurementId", rels[0].FieldName)
+	assert.Equal(t, "MeasurementDescriptionDataType", rels[0].TargetType)
+	assert.Equal(t, "MeasurementId", rels[0].TargetField)
+	assert.False(t, rels[0].IsComposite, "MeasurementId is not part of a composite key")
+}
+
+func TestGetRelationships_LoadControlLimitData(t *testing.T) {
+	data := LoadControlLimitDataType{}
+	rels := GetRelationships(data)
+
+	assert.Len(t, rels, 1, "LoadControlLimitDataType should have 1 relationship")
+	assert.Equal(t, "LimitId", rels[0].FieldName)
+	assert.Equal(t, "LoadControlLimitDescriptionDataType", rels[0].TargetType)
+	assert.Equal(t, "LimitId", rels[0].TargetField)
+	assert.True(t, rels[0].IsComposite, "LimitId is a primary key")
+}
+
+func TestGetRelationships_MeasurementData(t *testing.T) {
+	data := MeasurementDataType{}
+	rels := GetRelationships(data)
+
+	assert.Len(t, rels, 1, "MeasurementDataType should have 1 relationship")
+	assert.Equal(t, "MeasurementId", rels[0].FieldName)
+	assert.Equal(t, "MeasurementDescriptionDataType", rels[0].TargetType)
+	assert.Equal(t, "MeasurementId", rels[0].TargetField)
+	assert.True(t, rels[0].IsComposite, "MeasurementId is a primary key")
+}
+
+func TestGetRelationships_ElectricalConnectionParameterDescription(t *testing.T) {
+	data := ElectricalConnectionParameterDescriptionDataType{}
+	rels := GetRelationships(data)
+
+	assert.Len(t, rels, 1, "ElectricalConnectionParameterDescriptionDataType should have 1 relationship")
+	assert.Equal(t, "MeasurementId", rels[0].FieldName)
+	assert.Equal(t, "MeasurementDescriptionDataType", rels[0].TargetType)
+	assert.Equal(t, "MeasurementId", rels[0].TargetField)
+	assert.False(t, rels[0].IsComposite, "MeasurementId is not part of the composite key")
+}
+
+func TestGetRelationships_ElectricalConnectionCharacteristic_CompositeKey(t *testing.T) {
+	data := ElectricalConnectionCharacteristicDataType{}
+	rels := GetRelationships(data)
+
+	assert.Len(t, rels, 2, "ElectricalConnectionCharacteristicDataType should have 2 relationship fields (composite foreign key)")
+
+	// Check ElectricalConnectionId relationship
+	var ecIdRel *RelationshipInfo
+	for i := range rels {
+		if rels[i].FieldName == "ElectricalConnectionId" {
+			ecIdRel = &rels[i]
+			break
+		}
+	}
+	assert.NotNil(t, ecIdRel, "Should have ElectricalConnectionId relationship")
+	assert.Equal(t, "ElectricalConnectionParameterDescriptionDataType", ecIdRel.TargetType)
+	assert.Equal(t, "ElectricalConnectionId", ecIdRel.TargetField)
+	assert.True(t, ecIdRel.IsComposite, "ElectricalConnectionId is part of composite key")
+
+	// Check ParameterId relationship
+	var paramIdRel *RelationshipInfo
+	for i := range rels {
+		if rels[i].FieldName == "ParameterId" {
+			paramIdRel = &rels[i]
+			break
+		}
+	}
+	assert.NotNil(t, paramIdRel, "Should have ParameterId relationship")
+	assert.Equal(t, "ElectricalConnectionParameterDescriptionDataType", paramIdRel.TargetType)
+	assert.Equal(t, "ParameterId", paramIdRel.TargetField)
+	assert.True(t, paramIdRel.IsComposite, "ParameterId is part of composite key")
+}
+
+func TestGetRelationships_NoRelationships(t *testing.T) {
+	// MeasurementDescriptionDataType is a target, not a source, so it should have no relationships
+	data := MeasurementDescriptionDataType{}
+	rels := GetRelationships(data)
+
+	assert.Len(t, rels, 0, "MeasurementDescriptionDataType should have no outgoing relationships")
+}
+
+func TestGetRelationshipsByFieldName(t *testing.T) {
+	data := LoadControlLimitDescriptionDataType{}
+
+	// Test existing field
+	rel := GetRelationshipsByFieldName(data, "MeasurementId")
+	assert.NotNil(t, rel)
+	assert.Equal(t, "MeasurementDescriptionDataType", rel.TargetType)
+
+	// Test non-existent field
+	rel = GetRelationshipsByFieldName(data, "NonExistentField")
+	assert.Nil(t, rel)
+}
+
+func TestHasRelationships(t *testing.T) {
+	// Type with relationships
+	data := LoadControlLimitDescriptionDataType{}
+	assert.True(t, HasRelationships(data))
+
+	// Type without relationships
+	desc := MeasurementDescriptionDataType{}
+	assert.False(t, HasRelationships(desc))
+}
+
+func TestGetRelationships_WithPointer(t *testing.T) {
+	// Test that function works with pointer types too
+	data := &LoadControlLimitDescriptionDataType{}
+	rels := GetRelationships(data)
+
+	assert.Len(t, rels, 1)
+	assert.Equal(t, "MeasurementId", rels[0].FieldName)
+}
+
+func TestGetRelationships_InvalidType(t *testing.T) {
+	// Test with nil
+	rels := GetRelationships(nil)
+	assert.Len(t, rels, 0)
+
+	// Test with non-struct type
+	rels = GetRelationships("not a struct")
+	assert.Len(t, rels, 0)
+}

--- a/model/relationship_helper_test.go
+++ b/model/relationship_helper_test.go
@@ -43,11 +43,26 @@ func TestGetRelationships_ElectricalConnectionParameterDescription(t *testing.T)
 	data := ElectricalConnectionParameterDescriptionDataType{}
 	rels := GetRelationships(data)
 
-	assert.Len(t, rels, 1, "ElectricalConnectionParameterDescriptionDataType should have 1 relationship")
-	assert.Equal(t, "MeasurementId", rels[0].FieldName)
-	assert.Equal(t, "MeasurementDescriptionDataType", rels[0].TargetType)
-	assert.Equal(t, "MeasurementId", rels[0].TargetField)
-	assert.False(t, rels[0].IsComposite, "MeasurementId is not part of the composite key")
+	assert.Len(t, rels, 2, "ElectricalConnectionParameterDescriptionDataType should have 2 relationships")
+
+	// Check both relationships exist
+	var foundElectricalConnectionId, foundMeasurementId bool
+	for _, rel := range rels {
+		if rel.FieldName == "ElectricalConnectionId" {
+			assert.Equal(t, "ElectricalConnectionDescriptionDataType", rel.TargetType)
+			assert.Equal(t, "ElectricalConnectionId", rel.TargetField)
+			assert.True(t, rel.IsComposite, "ElectricalConnectionId is part of the composite key")
+			foundElectricalConnectionId = true
+		}
+		if rel.FieldName == "MeasurementId" {
+			assert.Equal(t, "MeasurementDescriptionDataType", rel.TargetType)
+			assert.Equal(t, "MeasurementId", rel.TargetField)
+			assert.False(t, rel.IsComposite, "MeasurementId is not part of the composite key")
+			foundMeasurementId = true
+		}
+	}
+	assert.True(t, foundElectricalConnectionId, "Should have ElectricalConnectionId relationship")
+	assert.True(t, foundMeasurementId, "Should have MeasurementId relationship")
 }
 
 func TestGetRelationships_ElectricalConnectionCharacteristic_CompositeKey(t *testing.T) {

--- a/model/setpoint.go
+++ b/model/setpoint.go
@@ -10,7 +10,7 @@ const (
 )
 
 type SetpointDataType struct {
-	SetpointId               *SetpointIdType   `json:"setpointId,omitempty" eebus:"key,primarykey"`
+	SetpointId               *SetpointIdType   `json:"setpointId,omitempty" eebus:"key,primarykey,ref:SetpointDescriptionDataType.SetpointId"`
 	Value                    *ScaledNumberType `json:"value,omitempty"`
 	ValueMin                 *ScaledNumberType `json:"valueMin,omitempty"`
 	ValueMax                 *ScaledNumberType `json:"valueMax,omitempty"`
@@ -42,7 +42,7 @@ type SetpointListDataSelectorsType struct {
 }
 
 type SetpointConstraintsDataType struct {
-	SetpointId       *SetpointIdType   `json:"setpointId,omitempty" eebus:"key,primarykey"`
+	SetpointId       *SetpointIdType   `json:"setpointId,omitempty" eebus:"key,primarykey,ref:SetpointDescriptionDataType.SetpointId"`
 	SetpointRangeMin *ScaledNumberType `json:"setpointRangeMin,omitempty"`
 	SetpointRangeMax *ScaledNumberType `json:"setpointRangeMax,omitempty"`
 	SetpointStepSize *ScaledNumberType `json:"setpointStepSize,omitempty"`

--- a/model/supplyconditions.go
+++ b/model/supplyconditions.go
@@ -34,7 +34,7 @@ const (
 )
 
 type SupplyConditionDataType struct {
-	ConditionId         *ConditionIdType               `json:"conditionId,omitempty" eebus:"key,primarykey"`
+	ConditionId         *ConditionIdType               `json:"conditionId,omitempty" eebus:"key,primarykey,ref:SupplyConditionDescriptionDataType.ConditionId"`
 	Timestamp           *AbsoluteOrRelativeTimeType    `json:"timestamp,omitempty"`
 	EventType           *SupplyConditionEventTypeType  `json:"eventType,omitempty"`
 	Originator          *SupplyConditionOriginatorType `json:"originator,omitempty"`

--- a/model/supplyconditions.go
+++ b/model/supplyconditions.go
@@ -38,7 +38,7 @@ type SupplyConditionDataType struct {
 	Timestamp           *AbsoluteOrRelativeTimeType    `json:"timestamp,omitempty"`
 	EventType           *SupplyConditionEventTypeType  `json:"eventType,omitempty"`
 	Originator          *SupplyConditionOriginatorType `json:"originator,omitempty"`
-	ThresholdId         *ThresholdIdType               `json:"thresholdId,omitempty"`
+	ThresholdId         *ThresholdIdType               `json:"thresholdId,omitempty" eebus:"ref:ThresholdDescriptionDataType.ThresholdId"`
 	ThresholdPercentage *ScaledNumberType              `json:"thresholdPercentage,omitempty"`
 	RelevantPeriod      *TimePeriodType                `json:"relevantPeriod,omitempty"`
 	Description         *DescriptionType               `json:"description,omitempty"`

--- a/model/tariffinformation.go
+++ b/model/tariffinformation.go
@@ -76,7 +76,7 @@ type TariffOverallConstraintsDataElementsType struct {
 }
 
 type TariffDataType struct {
-	TariffId     *TariffIdType `json:"tariffId,omitempty" eebus:"key,primarykey"`
+	TariffId     *TariffIdType `json:"tariffId,omitempty" eebus:"key,primarykey,ref:TariffDescriptionDataType.TariffId"`
 	ActiveTierId []TierIdType  `json:"activeTierId,omitempty"`
 }
 
@@ -95,7 +95,7 @@ type TariffListDataSelectorsType struct {
 }
 
 type TariffTierRelationDataType struct {
-	TariffId *TariffIdType `json:"tariffId,omitempty" eebus:"key,primarykey"`
+	TariffId *TariffIdType `json:"tariffId,omitempty" eebus:"key,primarykey,ref:TariffDescriptionDataType.TariffId"`
 	TierId   []TierIdType  `json:"tierId,omitempty"`
 }
 
@@ -114,7 +114,7 @@ type TariffTierRelationListDataSelectorsType struct {
 }
 
 type TariffBoundaryRelationDataType struct {
-	TariffId   *TariffIdType        `json:"tariffId,omitempty" eebus:"key,primarykey"`
+	TariffId   *TariffIdType        `json:"tariffId,omitempty" eebus:"key,primarykey,ref:TariffDescriptionDataType.TariffId"`
 	BoundaryId []TierBoundaryIdType `json:"boundaryId,omitempty"`
 }
 
@@ -168,7 +168,7 @@ type TariffDescriptionListDataSelectorsType struct {
 }
 
 type TierBoundaryDataType struct {
-	BoundaryId         *TierBoundaryIdType `json:"boundaryId,omitempty" eebus:"key,primarykey"`
+	BoundaryId         *TierBoundaryIdType `json:"boundaryId,omitempty" eebus:"key,primarykey,ref:TierBoundaryDescriptionDataType.BoundaryId"`
 	TimePeriod         *TimePeriodType     `json:"timePeriod,omitempty"`
 	TimeTableId        *TimeTableIdType    `json:"timeTableId,omitempty" eebus:"ref:TimeTableDescriptionDataType.TimeTableId"`
 	LowerBoundaryValue *ScaledNumberType   `json:"lowerBoundaryValue,omitempty"`
@@ -248,7 +248,7 @@ type CommodityListDataSelectorsType struct {
 }
 
 type TierDataType struct {
-	TierId            *TierIdType       `json:"tierId,omitempty" eebus:"key,primarykey"`
+	TierId            *TierIdType       `json:"tierId,omitempty" eebus:"key,primarykey,ref:TierDescriptionDataType.TierId"`
 	TimePeriod        *TimePeriodType   `json:"timePeriod,omitempty"`
 	TimeTableId       *TimeTableIdType  `json:"timeTableId,omitempty" eebus:"ref:TimeTableDescriptionDataType.TimeTableId"`
 	ActiveIncentiveId []IncentiveIdType `json:"activeIncentiveId,omitempty"`
@@ -271,7 +271,7 @@ type TierListDataSelectorsType struct {
 }
 
 type TierIncentiveRelationDataType struct {
-	TierId      *TierIdType       `json:"tierId,omitempty" eebus:"key,primarykey"`
+	TierId      *TierIdType       `json:"tierId,omitempty" eebus:"key,primarykey,ref:TierDescriptionDataType.TierId"`
 	IncentiveId []IncentiveIdType `json:"incentiveId,omitempty"`
 }
 
@@ -313,7 +313,7 @@ type TierDescriptionListDataSelectorsType struct {
 }
 
 type IncentiveDataType struct {
-	IncentiveId *IncentiveIdType            `json:"incentiveId,omitempty" eebus:"key,primarykey"`
+	IncentiveId *IncentiveIdType            `json:"incentiveId,omitempty" eebus:"key,primarykey,ref:IncentiveDescriptionDataType.IncentiveId"`
 	ValueType   *IncentiveValueTypeType     `json:"valueType,omitempty"`
 	Timestamp   *AbsoluteOrRelativeTimeType `json:"timestamp,omitempty"`
 	TimePeriod  *TimePeriodType             `json:"timePeriod,omitempty"`

--- a/model/tariffinformation.go
+++ b/model/tariffinformation.go
@@ -135,7 +135,7 @@ type TariffBoundaryRelationListDataSelectorsType struct {
 type TariffDescriptionDataType struct {
 	TariffId        *TariffIdType      `json:"tariffId,omitempty" eebus:"key,primarykey"`
 	CommodityId     *CommodityIdType   `json:"commodityId,omitempty"`
-	MeasurementId   *MeasurementIdType `json:"measurementId,omitempty"`
+	MeasurementId   *MeasurementIdType `json:"measurementId,omitempty" eebus:"ref:MeasurementDescriptionDataType.MeasurementId"`
 	TariffWriteable *bool              `json:"tariffWriteable,omitempty"`
 	UpdateRequired  *bool              `json:"updateRequired,omitempty"`
 	ScopeType       *ScopeTypeType     `json:"scopeType,omitempty"`
@@ -170,7 +170,7 @@ type TariffDescriptionListDataSelectorsType struct {
 type TierBoundaryDataType struct {
 	BoundaryId         *TierBoundaryIdType `json:"boundaryId,omitempty" eebus:"key,primarykey"`
 	TimePeriod         *TimePeriodType     `json:"timePeriod,omitempty"`
-	TimeTableId        *TimeTableIdType    `json:"timeTableId,omitempty"`
+	TimeTableId        *TimeTableIdType    `json:"timeTableId,omitempty" eebus:"ref:TimeTableDescriptionDataType.TimeTableId"`
 	LowerBoundaryValue *ScaledNumberType   `json:"lowerBoundaryValue,omitempty"`
 	UpperBoundaryValue *ScaledNumberType   `json:"upperBoundaryValue,omitempty"`
 }
@@ -194,9 +194,9 @@ type TierBoundaryListDataSelectorsType struct {
 type TierBoundaryDescriptionDataType struct {
 	BoundaryId               *TierBoundaryIdType    `json:"boundaryId,omitempty" eebus:"key,primarykey"`
 	BoundaryType             *TierBoundaryTypeType  `json:"boundaryType,omitempty"`
-	ValidForTierId           *TierIdType            `json:"validForTierId,omitempty"`
-	SwitchToTierIdWhenLower  *TierIdType            `json:"switchToTierIdWhenLower,omitempty"`
-	SwitchToTierIdWhenHigher *TierIdType            `json:"switchToTierIdWhenHigher,omitempty"`
+	ValidForTierId           *TierIdType            `json:"validForTierId,omitempty" eebus:"ref:TierDescriptionDataType.TierId"`
+	SwitchToTierIdWhenLower  *TierIdType            `json:"switchToTierIdWhenLower,omitempty" eebus:"ref:TierDescriptionDataType.TierId"`
+	SwitchToTierIdWhenHigher *TierIdType            `json:"switchToTierIdWhenHigher,omitempty" eebus:"ref:TierDescriptionDataType.TierId"`
 	BoundaryUnit             *UnitOfMeasurementType `json:"boundaryUnit,omitempty"`
 	Label                    *LabelType             `json:"label,omitempty"`
 	Description              *DescriptionType       `json:"description,omitempty"`
@@ -250,7 +250,7 @@ type CommodityListDataSelectorsType struct {
 type TierDataType struct {
 	TierId            *TierIdType       `json:"tierId,omitempty" eebus:"key,primarykey"`
 	TimePeriod        *TimePeriodType   `json:"timePeriod,omitempty"`
-	TimeTableId       *TimeTableIdType  `json:"timeTableId,omitempty"`
+	TimeTableId       *TimeTableIdType  `json:"timeTableId,omitempty" eebus:"ref:TimeTableDescriptionDataType.TimeTableId"`
 	ActiveIncentiveId []IncentiveIdType `json:"activeIncentiveId,omitempty"`
 }
 
@@ -317,7 +317,7 @@ type IncentiveDataType struct {
 	ValueType   *IncentiveValueTypeType     `json:"valueType,omitempty"`
 	Timestamp   *AbsoluteOrRelativeTimeType `json:"timestamp,omitempty"`
 	TimePeriod  *TimePeriodType             `json:"timePeriod,omitempty"`
-	TimeTableId *TimeTableIdType            `json:"timeTableId,omitempty"`
+	TimeTableId *TimeTableIdType            `json:"timeTableId,omitempty" eebus:"ref:TimeTableDescriptionDataType.TimeTableId"`
 	Value       *ScaledNumberType           `json:"value,omitempty"`
 }
 

--- a/model/taskmanagement.go
+++ b/model/taskmanagement.go
@@ -43,7 +43,7 @@ type TaskManagementDirectControlRelatedType struct{}
 type TaskManagementDirectControlRelatedElementsType struct{}
 
 type TaskManagementHvacRelatedType struct {
-	OverrunId *HvacOverrunIdType `json:"overrunId,omitempty"`
+	OverrunId *HvacOverrunIdType `json:"overrunId,omitempty" eebus:"ref:HvacOverrunDescriptionDataType.OverrunId"`
 }
 
 type TaskManagementHvacRelatedElementsType struct {
@@ -51,7 +51,7 @@ type TaskManagementHvacRelatedElementsType struct {
 }
 
 type TaskManagementLoadControlReleatedType struct {
-	EventId *LoadControlEventIdType `json:"eventId,omitempty"`
+	EventId *LoadControlEventIdType `json:"eventId,omitempty" eebus:"ref:LoadControlEventDataType.EventId"`
 }
 
 type TaskManagementLoadControlReleatedElementsType struct {
@@ -59,7 +59,7 @@ type TaskManagementLoadControlReleatedElementsType struct {
 }
 
 type TaskManagementPowerSequencesRelatedType struct {
-	SequenceId *PowerSequenceIdType `json:"sequenceId,omitempty"`
+	SequenceId *PowerSequenceIdType `json:"sequenceId,omitempty" eebus:"ref:PowerSequenceDescriptionDataType.SequenceId"`
 }
 
 type TaskManagementPowerSequencesRelatedElementsType struct {
@@ -67,7 +67,7 @@ type TaskManagementPowerSequencesRelatedElementsType struct {
 }
 
 type TaskManagementSmartEnergyManagementPsRelatedType struct {
-	SequenceId *PowerSequenceIdType `json:"sequenceId,omitempty"`
+	SequenceId *PowerSequenceIdType `json:"sequenceId,omitempty" eebus:"ref:PowerSequenceDescriptionDataType.SequenceId"`
 }
 
 type TaskManagementSmartEnergyManagementPsRelatedElementsType struct {

--- a/model/threshold.go
+++ b/model/threshold.go
@@ -18,7 +18,7 @@ const (
 )
 
 type ThresholdDataType struct {
-	ThresholdId    *ThresholdIdType  `json:"thresholdId,omitempty" eebus:"key,primarykey"`
+	ThresholdId    *ThresholdIdType  `json:"thresholdId,omitempty" eebus:"key,primarykey,ref:ThresholdDescriptionDataType.ThresholdId"`
 	ThresholdValue *ScaledNumberType `json:"thresholdValue,omitempty"`
 }
 
@@ -36,7 +36,7 @@ type ThresholdListDataSelectorsType struct {
 }
 
 type ThresholdConstraintsDataType struct {
-	ThresholdId       *ThresholdIdType  `json:"thresholdId,omitempty" eebus:"key,primarykey"`
+	ThresholdId       *ThresholdIdType  `json:"thresholdId,omitempty" eebus:"key,primarykey,ref:ThresholdDescriptionDataType.ThresholdId"`
 	ThresholdRangeMin *ScaledNumberType `json:"thresholdRangeMin,omitempty"`
 	ThresholdRangeMax *ScaledNumberType `json:"thresholdRangeMax,omitempty"`
 	ThresholdStepSize *ScaledNumberType `json:"thresholdStepSize,omitempty"`

--- a/model/timeseries.go
+++ b/model/timeseries.go
@@ -39,7 +39,7 @@ type TimeSeriesSlotElementsType struct {
 }
 
 type TimeSeriesDataType struct {
-	TimeSeriesId   *TimeSeriesIdType    `json:"timeSeriesId,omitempty" eebus:"key,primarykey"`
+	TimeSeriesId   *TimeSeriesIdType    `json:"timeSeriesId,omitempty" eebus:"key,primarykey,ref:TimeSeriesDescriptionDataType.TimeSeriesId"`
 	TimePeriod     *TimePeriodType      `json:"timePeriod,omitempty"`
 	TimeSeriesSlot []TimeSeriesSlotType `json:"timeSeriesSlot"`
 }
@@ -97,7 +97,7 @@ type TimeSeriesDescriptionListDataSelectorsType struct {
 }
 
 type TimeSeriesConstraintsDataType struct {
-	TimeSeriesId                *TimeSeriesIdType           `json:"timeSeriesId,omitempty" eebus:"key,primarykey"`
+	TimeSeriesId                *TimeSeriesIdType           `json:"timeSeriesId,omitempty" eebus:"key,primarykey,ref:TimeSeriesDescriptionDataType.TimeSeriesId"`
 	SlotCountMin                *TimeSeriesSlotCountType    `json:"slotCountMin,omitempty"`
 	SlotCountMax                *TimeSeriesSlotCountType    `json:"slotCountMax,omitempty"`
 	SlotDurationMin             *DurationType               `json:"slotDurationMin,omitempty"`

--- a/model/timeseries.go
+++ b/model/timeseries.go
@@ -64,7 +64,7 @@ type TimeSeriesDescriptionDataType struct {
 	TimeSeriesType      *TimeSeriesTypeType    `json:"timeSeriesType,omitempty"`
 	TimeSeriesWriteable *bool                  `json:"timeSeriesWriteable,omitempty"`
 	UpdateRequired      *bool                  `json:"updateRequired,omitempty"`
-	MeasurementId       *MeasurementIdType     `json:"measurementId,omitempty"`
+	MeasurementId       *MeasurementIdType     `json:"measurementId,omitempty" eebus:"ref:MeasurementDescriptionDataType.MeasurementId"`
 	Currency            *CurrencyType          `json:"currency,omitempty"`
 	Unit                *UnitOfMeasurementType `json:"unit,omitempty"`
 	Label               *LabelType             `json:"label,omitempty"`

--- a/model/timetable.go
+++ b/model/timetable.go
@@ -15,7 +15,7 @@ const (
 )
 
 type TimeTableDataType struct {
-	TimeTableId           *TimeTableIdType             `json:"timeTableId,omitempty" eebus:"key,primarykey"`
+	TimeTableId           *TimeTableIdType             `json:"timeTableId,omitempty" eebus:"key,primarykey,ref:TimeTableDescriptionDataType.TimeTableId"`
 	TimeSlotId            *TimeSlotIdType              `json:"timeSlotId,omitempty"`
 	RecurrenceInformation *RecurrenceInformationType   `json:"recurrenceInformation,omitempty"`
 	StartTime             *AbsoluteOrRecurringTimeType `json:"startTime,omitempty"`
@@ -40,7 +40,7 @@ type TimeTableListDataSelectorsType struct {
 }
 
 type TimeTableConstraintsDataType struct {
-	TimeTableId          *TimeTableIdType   `json:"timeTableId,omitempty" eebus:"key,primarykey"`
+	TimeTableId          *TimeTableIdType   `json:"timeTableId,omitempty" eebus:"key,primarykey,ref:TimeTableDescriptionDataType.TimeTableId"`
 	SlotCountMin         *TimeSlotCountType `json:"slotCountMin,omitempty"`
 	SlotCountMax         *TimeSlotCountType `json:"slotCountMax,omitempty"`
 	SlotDurationMin      *DurationType      `json:"slotDurationMin,omitempty"`


### PR DESCRIPTION
Add tag support for being able to automatically resolved referenced index values.

E.g. `LoadControlLimitDataType` has `LimitId` being a reference to a specific item in `LoadControlLimitListDataType` matching a specific fields `LimitId` value.

This way a generic resolving of these (recursive) dependencies between data structure can be implemented.