### PR TITLE
Fix potential crashes due to missing nil checks

### DIFF
--- a/model/commandframe_additions.go
+++ b/model/commandframe_additions.go
@@ -290,6 +290,9 @@ func (cmd *CmdType) DataName() string {
 func (cmd *CmdType) ExtractFilter() (filterPartial *FilterType, filterDelete *FilterType) {
 	if cmd != nil && cmd.Filter != nil && len(cmd.Filter) > 0 {
 		for i := range cmd.Filter {
+			if cmd.Filter[i].CmdControl == nil {
+				continue
+			}
 			if cmd.Filter[i].CmdControl.Partial != nil {
 				filterPartial = &cmd.Filter[i]
 			} else if cmd.Filter[i].CmdControl.Delete != nil {

--- a/model/datagram_additions.go
+++ b/model/datagram_additions.go
@@ -14,7 +14,7 @@ func (d *DatagramType) PrintMessageOverview(send bool, localFeature, remoteFeatu
 	}
 	if !send {
 		transmission = "Recv"
-		if d.Header.AddressSource.Device != nil {
+		if d.Header.AddressSource != nil && d.Header.AddressSource.Device != nil {
 			device = string(*d.Header.AddressSource.Device)
 		}
 		device = fmt.Sprintf("%s:%s to %s", device, remoteFeature, localFeature)
@@ -37,11 +37,20 @@ func (d *DatagramType) PrintMessageOverview(send bool, localFeature, remoteFeatu
 	case CmdClassifierTypeRead:
 		result = fmt.Sprintf("%s: %s %s %d %s", transmission, device, cmdClassifier, msgCounter, cmd.DataName())
 	case CmdClassifierTypeReply:
-		msgCounterRef := *d.Header.MsgCounterReference
+		msgCounterRef := MsgCounterType(0)
+		if d.Header.MsgCounterReference != nil {
+			msgCounterRef = *d.Header.MsgCounterReference
+		}
 		result = fmt.Sprintf("%s: %s %s %d %d %s", transmission, device, cmdClassifier, msgCounter, msgCounterRef, cmd.DataName())
 	case CmdClassifierTypeResult:
-		msgCounterRef := *d.Header.MsgCounterReference
-		errorNumber := *d.Payload.Cmd[0].ResultData.ErrorNumber
+		msgCounterRef := MsgCounterType(0)
+		if d.Header.MsgCounterReference != nil {
+			msgCounterRef = *d.Header.MsgCounterReference
+		}
+		errorNumber := ErrorNumberType(0)
+		if len(d.Payload.Cmd) > 0 && d.Payload.Cmd[0].ResultData != nil && d.Payload.Cmd[0].ResultData.ErrorNumber != nil {
+			errorNumber = *d.Payload.Cmd[0].ResultData.ErrorNumber
+		}
 		result = fmt.Sprintf("%s: %s %s %d %d %s %d", transmission, device, cmdClassifier, msgCounter, msgCounterRef, cmd.DataName(), errorNumber)
 	default:
 		result = fmt.Sprintf("%s: %s %s %d %s", transmission, device, cmdClassifier, msgCounter, cmd.DataName())

--- a/spine/binding_manager.go
+++ b/spine/binding_manager.go
@@ -213,8 +213,14 @@ func (c *BindingManager) RemoveBindingsForLocalEntity(localEntity api.EntityLoca
 		var remoteDevice api.DeviceRemoteInterface
 
 		if reflect.DeepEqual(binding.ClientAddress.Device, localDeviceAddress) {
+			if binding.ServerAddress == nil || binding.ServerAddress.Device == nil {
+				continue
+			}
 			remoteDevice = c.localDevice.RemoteDeviceForAddress(*binding.ServerAddress.Device)
 		} else {
+			if binding.ClientAddress == nil || binding.ClientAddress.Device == nil {
+				continue
+			}
 			remoteDevice = c.localDevice.RemoteDeviceForAddress(*binding.ClientAddress.Device)
 		}
 

--- a/spine/binding_manager.go
+++ b/spine/binding_manager.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/enbility/ship-go/logging"
 	"github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
 )
@@ -213,12 +214,16 @@ func (c *BindingManager) RemoveBindingsForLocalEntity(localEntity api.EntityLoca
 		var remoteDevice api.DeviceRemoteInterface
 
 		if reflect.DeepEqual(binding.ClientAddress.Device, localDeviceAddress) {
+			// defense in depth in case invalid bindings are ever added
 			if binding.ServerAddress == nil || binding.ServerAddress.Device == nil {
+				logging.Log().Debug("skipping invalid binding with unset ServerAddress")
 				continue
 			}
 			remoteDevice = c.localDevice.RemoteDeviceForAddress(*binding.ServerAddress.Device)
 		} else {
+			// defense in depth in case invalid bindings are ever added
 			if binding.ClientAddress == nil || binding.ClientAddress.Device == nil {
+				logging.Log().Debug("skipping invalid binding with unset ClientAddress")
 				continue
 			}
 			remoteDevice = c.localDevice.RemoteDeviceForAddress(*binding.ClientAddress.Device)

--- a/spine/device_local.go
+++ b/spine/device_local.go
@@ -501,6 +501,9 @@ func (r *DeviceLocal) NotifySubscribers(featureAddress *model.FeatureAddressType
 	for _, subscription := range subscriptions {
 		// get the server feature, it has to be a local feature
 		serverFeature := r.FeatureByAddress(subscription.ServerAddress)
+		if subscription.ClientAddress == nil || subscription.ClientAddress.Device == nil {
+			continue
+		}
 		remoteDevice := r.RemoteDeviceForAddress(*subscription.ClientAddress.Device)
 		if serverFeature == nil || remoteDevice == nil {
 			continue

--- a/spine/nodemanagement_detaileddiscovery.go
+++ b/spine/nodemanagement_detaileddiscovery.go
@@ -53,6 +53,9 @@ func (r *NodeManagement) processReadDetailedDiscoveryData(deviceRemote api.Devic
 func (r *NodeManagement) processReplyDetailedDiscoveryData(message *api.Message, data *model.NodeManagementDetailedDiscoveryDataType) error {
 	remoteDevice := message.DeviceRemote
 
+	if data.DeviceInformation == nil {
+		return errors.New("nodemanagement.replyDetailedDiscoveryData: invalid DeviceInformation")
+	}
 	deviceDescription := data.DeviceInformation.Description
 	if deviceDescription == nil {
 		return errors.New("nodemanagement.replyDetailedDiscoveryData: invalid DeviceInformation.Description")

--- a/spine/subscription_manager.go
+++ b/spine/subscription_manager.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/enbility/ship-go/logging"
 	"github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
 )
@@ -204,12 +205,16 @@ func (c *SubscriptionManager) RemoveSubscriptionsForLocalEntity(localEntity api.
 		var remoteDevice api.DeviceRemoteInterface
 
 		if reflect.DeepEqual(subscription.ClientAddress.Device, localDeviceAddress) {
+			// defense in depth in case invalid subscriptions are ever added
 			if subscription.ServerAddress == nil || subscription.ServerAddress.Device == nil {
+				logging.Log().Debug("skipping invalid subscription with unset ServerAddress")
 				continue
 			}
 			remoteDevice = c.localDevice.RemoteDeviceForAddress(*subscription.ServerAddress.Device)
 		} else {
+			// defense in depth in case invalid subscriptions are ever added
 			if subscription.ClientAddress == nil || subscription.ClientAddress.Device == nil {
+				logging.Log().Debug("skipping invalid subscription with unset ClientAddress")
 				continue
 			}
 			remoteDevice = c.localDevice.RemoteDeviceForAddress(*subscription.ClientAddress.Device)
@@ -222,7 +227,7 @@ func (c *SubscriptionManager) RemoveSubscriptionsForLocalEntity(localEntity api.
 	}
 }
 
-// Checks if a binding between the client and server feature exists
+// Checks if a subscription between the client and server feature exists
 func (c *SubscriptionManager) HasSubscription(clientAddress, serverAddress *model.FeatureAddressType) bool {
 	subscriptionData := c.subscriptionData()
 

--- a/spine/subscription_manager.go
+++ b/spine/subscription_manager.go
@@ -204,8 +204,14 @@ func (c *SubscriptionManager) RemoveSubscriptionsForLocalEntity(localEntity api.
 		var remoteDevice api.DeviceRemoteInterface
 
 		if reflect.DeepEqual(subscription.ClientAddress.Device, localDeviceAddress) {
+			if subscription.ServerAddress == nil || subscription.ServerAddress.Device == nil {
+				continue
+			}
 			remoteDevice = c.localDevice.RemoteDeviceForAddress(*subscription.ServerAddress.Device)
 		} else {
+			if subscription.ClientAddress == nil || subscription.ClientAddress.Device == nil {
+				continue
+			}
 			remoteDevice = c.localDevice.RemoteDeviceForAddress(*subscription.ClientAddress.Device)
 		}
 


### PR DESCRIPTION
In some instances in the repository the code did access child elements without checking the parent elements. So if the remote device send a malformed code structure, this would trigger a crash.