### PR TITLE
Remove global Events, each DeviceLocal owns its events manager

### DIFF
--- a/api/device.go
+++ b/api/device.go
@@ -76,6 +76,11 @@ type DeviceLocalInterface interface {
 	// Send a notify message to remote device subscribing to a specific feature
 	NotifySubscribers(featureAddress *model.FeatureAddressType, cmd model.CmdType)
 
+	// Get the events manager for this device.
+	// Each device owns its own events manager for automatic isolation.
+	// Use this to subscribe to SPINE events for this device.
+	Events() EventsManagerInterface
+
 	// Get the SPINE data structure for NodeManagementDetailDiscoveryData messages for this device
 	Information() *model.NodeManagementDetailedDiscoveryDeviceInformationType
 }

--- a/api/events.go
+++ b/api/events.go
@@ -39,3 +39,15 @@ type EventPayload struct {
 	CmdClassifier *model.CmdClassifierType // optional, used together with EventType EventTypeDataChange
 	Data          any
 }
+
+// EventsManagerInterface defines the interface for managing event subscriptions and publishing.
+// This interface allows for dependency injection of the events manager, enabling
+// test isolation when multiple DeviceLocal instances exist in the same process.
+type EventsManagerInterface interface {
+	// Subscribe registers an event handler to receive events at the application level.
+	Subscribe(handler EventHandlerInterface) error
+	// Unsubscribe removes an event handler from receiving events.
+	Unsubscribe(handler EventHandlerInterface) error
+	// Publish sends an event to all registered handlers.
+	Publish(payload EventPayload)
+}

--- a/spine/binding_manager.go
+++ b/spine/binding_manager.go
@@ -76,7 +76,7 @@ func (c *BindingManager) AddBinding(remoteDevice api.DeviceRemoteInterface, data
 		Feature:      remoteFeature,
 		LocalFeature: localFeature,
 	}
-	Events.Publish(payload)
+	c.localDevice.Events().Publish(payload)
 
 	return nil
 }
@@ -147,7 +147,7 @@ func (c *BindingManager) RemoveBinding(remoteDevice api.DeviceRemoteInterface, d
 				Feature:      remoteFeature,
 				LocalFeature: localFeature,
 			}
-			Events.Publish(payload)
+			c.localDevice.Events().Publish(payload)
 		}
 	}
 

--- a/spine/device_local.go
+++ b/spine/device_local.go
@@ -28,6 +28,8 @@ type DeviceLocal struct {
 	deviceCode   string
 	serialNumber string
 
+	events *events // events manager owned by this device
+
 	mux sync.Mutex
 }
 
@@ -54,6 +56,7 @@ func NewDeviceLocal(
 		deviceModel:   deviceModel,
 		serialNumber:  serialNumber,
 		deviceCode:    deviceCode,
+		events:        newEvents(), // each device owns its events manager
 	}
 
 	res.subscriptionManager = NewSubscriptionManager(res)
@@ -132,7 +135,7 @@ func (r *DeviceLocal) SetupRemoteDevice(ski string, writeI shipapi.ShipConnectio
 	r.AddRemoteDeviceForSki(ski, rDevice)
 
 	// always add subscription, as it checks if it already exists
-	_ = Events.subscribe(api.EventHandlerLevelCore, r)
+	_ = r.events.subscribe(api.EventHandlerLevelCore, r)
 
 	// Request Detailed Discovery Data
 	_, _ = r.RequestRemoteDetailedDiscoveryData(rDevice)
@@ -174,7 +177,7 @@ func (r *DeviceLocal) RemoveRemoteDeviceConnection(ski string) {
 		ChangeType: api.ElementChangeRemove,
 		Device:     remoteDevice,
 	}
-	Events.Publish(payload)
+	r.events.Publish(payload)
 }
 
 func (r *DeviceLocal) RemoveRemoteDevice(ski string) {
@@ -197,7 +200,7 @@ func (r *DeviceLocal) RemoveRemoteDevice(ski string) {
 
 	// only unsubscribe if we don't have any remote devices left
 	if len(r.remoteDevices) == 0 {
-		_ = Events.unsubscribe(api.EventHandlerLevelCore, r)
+		_ = r.events.unsubscribe(api.EventHandlerLevelCore, r)
 	}
 
 	r.mux.Unlock()
@@ -481,6 +484,10 @@ func (r *DeviceLocal) SubscriptionManager() api.SubscriptionManagerInterface {
 
 func (r *DeviceLocal) BindingManager() api.BindingManagerInterface {
 	return r.bindingManager
+}
+
+func (r *DeviceLocal) Events() api.EventsManagerInterface {
+	return r.events
 }
 
 func (r *DeviceLocal) Information() *model.NodeManagementDetailedDiscoveryDeviceInformationType {

--- a/spine/device_local_events_test.go
+++ b/spine/device_local_events_test.go
@@ -1,0 +1,39 @@
+package spine
+
+import (
+	"testing"
+
+	"github.com/enbility/spine-go/api"
+	"github.com/enbility/spine-go/model"
+	"github.com/stretchr/testify/assert"
+)
+
+// Test that DeviceLocal has Events() method returning its own events manager
+func TestDeviceLocalHasOwnEventsManager(t *testing.T) {
+	device := NewDeviceLocal("brand", "model", "serial", "code", "addr",
+		model.DeviceTypeTypeGeneric, model.NetworkManagementFeatureSetTypeSmart)
+
+	assert.NotNil(t, device.Events())
+}
+
+// Test that each DeviceLocal gets its own events manager (automatic isolation)
+func TestDeviceLocalEventsAreIsolated(t *testing.T) {
+	deviceA := NewDeviceLocal("brandA", "modelA", "serialA", "codeA", "addrA",
+		model.DeviceTypeTypeGeneric, model.NetworkManagementFeatureSetTypeSmart)
+
+	deviceB := NewDeviceLocal("brandB", "modelB", "serialB", "codeB", "addrB",
+		model.DeviceTypeTypeGeneric, model.NetworkManagementFeatureSetTypeSmart)
+
+	// Each device should have its own events manager (not same pointer)
+	assert.NotSame(t, deviceA.Events(), deviceB.Events())
+}
+
+// Test that DeviceLocalInterface includes Events() method
+func TestDeviceLocalInterfaceHasEvents(t *testing.T) {
+	device := NewDeviceLocal("brand", "model", "serial", "code", "addr",
+		model.DeviceTypeTypeGeneric, model.NetworkManagementFeatureSetTypeSmart)
+
+	// Use interface type to verify the method exists on the interface
+	var deviceInterface api.DeviceLocalInterface = device
+	assert.NotNil(t, deviceInterface.Events())
+}

--- a/spine/events.go
+++ b/spine/events.go
@@ -6,7 +6,15 @@ import (
 	"github.com/enbility/spine-go/api"
 )
 
-var Events events
+// newEvents creates a new events manager instance.
+// Each DeviceLocal creates its own events manager automatically.
+// Access it via device.Events() to subscribe to events for that device.
+func newEvents() *events {
+	return &events{}
+}
+
+// Verify that *events implements EventsManagerInterface at compile time
+var _ api.EventsManagerInterface = (*events)(nil)
 
 type eventHandlerItem struct {
 	Level   api.EventHandlerLevel

--- a/spine/events_interface_test.go
+++ b/spine/events_interface_test.go
@@ -1,0 +1,26 @@
+package spine
+
+import (
+	"testing"
+
+	"github.com/enbility/spine-go/api"
+	"github.com/stretchr/testify/assert"
+)
+
+// Test that events struct implements EventsManagerInterface
+func TestEventsImplementsInterface(t *testing.T) {
+	// Compile-time check: *events must satisfy EventsManagerInterface
+	var _ api.EventsManagerInterface = &events{}
+	var _ api.EventsManagerInterface = newEvents()
+
+	// Runtime check: newEvents returns a valid implementation
+	em := newEvents()
+	assert.NotNil(t, em)
+}
+
+// Test that newEvents() returns a type that satisfies the interface
+func TestNewEventsReturnsInterface(t *testing.T) {
+	em := newEvents()
+	var _ api.EventsManagerInterface = em
+	assert.NotNil(t, em)
+}

--- a/spine/events_isolation_test.go
+++ b/spine/events_isolation_test.go
@@ -1,0 +1,105 @@
+package spine
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/enbility/spine-go/api"
+	"github.com/enbility/spine-go/model"
+	"github.com/stretchr/testify/assert"
+)
+
+// testEventHandler is a simple event handler for testing
+type testEventHandler struct {
+	mu       sync.Mutex
+	events   []api.EventPayload
+	deviceID string // identifier to track which handler this is
+}
+
+func newTestEventHandler(deviceID string) *testEventHandler {
+	return &testEventHandler{
+		events:   make([]api.EventPayload, 0),
+		deviceID: deviceID,
+	}
+}
+
+func (h *testEventHandler) HandleEvent(payload api.EventPayload) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.events = append(h.events, payload)
+}
+
+func (h *testEventHandler) receivedEvents() []api.EventPayload {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	result := make([]api.EventPayload, len(h.events))
+	copy(result, h.events)
+	return result
+}
+
+// TestEventsIsolationBetweenDevices validates that two DeviceLocal instances
+// automatically have separate event managers and don't receive each other's events
+func TestEventsIsolationBetweenDevices(t *testing.T) {
+	// Create two devices - each automatically gets its own events manager
+	deviceA := NewDeviceLocal("brandA", "modelA", "serialA", "codeA", "addrA",
+		model.DeviceTypeTypeGeneric, model.NetworkManagementFeatureSetTypeSmart)
+
+	deviceB := NewDeviceLocal("brandB", "modelB", "serialB", "codeB", "addrB",
+		model.DeviceTypeTypeGeneric, model.NetworkManagementFeatureSetTypeSmart)
+
+	// Verify they have different events managers (automatic isolation)
+	assert.NotSame(t, deviceA.Events(), deviceB.Events())
+
+	// Create handlers for each device
+	handlerA := newTestEventHandler("deviceA")
+	handlerB := newTestEventHandler("deviceB")
+
+	// Subscribe handlers to their respective device's event managers
+	_ = deviceA.Events().Subscribe(handlerA)
+	_ = deviceB.Events().Subscribe(handlerB)
+
+	// Publish an event on device A's event manager
+	payloadA := api.EventPayload{
+		Ski:        "ski-device-a",
+		EventType:  api.EventTypeDataChange,
+		ChangeType: api.ElementChangeUpdate,
+	}
+	deviceA.Events().Publish(payloadA)
+
+	// Give async handlers time to process
+	time.Sleep(50 * time.Millisecond)
+
+	// Handler A should receive the event
+	eventsFromA := handlerA.receivedEvents()
+	assert.Len(t, eventsFromA, 1, "Handler A should receive 1 event")
+	assert.Equal(t, "ski-device-a", eventsFromA[0].Ski)
+
+	// Handler B should NOT receive the event (isolation!)
+	eventsFromB := handlerB.receivedEvents()
+	assert.Len(t, eventsFromB, 0, "Handler B should NOT receive events from device A")
+
+	// Now publish on device B
+	payloadB := api.EventPayload{
+		Ski:        "ski-device-b",
+		EventType:  api.EventTypeDeviceChange,
+		ChangeType: api.ElementChangeAdd,
+	}
+	deviceB.Events().Publish(payloadB)
+
+	// Give async handlers time to process
+	time.Sleep(50 * time.Millisecond)
+
+	// Handler B should now have 1 event
+	eventsFromB = handlerB.receivedEvents()
+	assert.Len(t, eventsFromB, 1, "Handler B should receive 1 event")
+	assert.Equal(t, "ski-device-b", eventsFromB[0].Ski)
+
+	// Handler A should still have only 1 event (no cross-talk)
+	eventsFromA = handlerA.receivedEvents()
+	assert.Len(t, eventsFromA, 1, "Handler A should still have only 1 event (no cross-talk)")
+
+	// Clean up subscriptions
+	_ = deviceA.Events().Unsubscribe(handlerA)
+	_ = deviceB.Events().Unsubscribe(handlerB)
+}

--- a/spine/events_test.go
+++ b/spine/events_test.go
@@ -24,10 +24,13 @@ type EventsTestSuite struct {
 
 	mux sync.Mutex
 
+	events *events // use instance instead of global
+
 	handlerInvoked bool
 }
 
 func (s *EventsTestSuite) BeforeTest(suiteName, testName string) {
+	s.events = newEvents() // fresh instance for each test
 	s.setHandlerInvoked(false)
 }
 
@@ -50,47 +53,47 @@ func (s *EventsTestSuite) HandleEvent(event api.EventPayload) {
 }
 
 func (s *EventsTestSuite) Test_Un_Subscribe() {
-	err := Events.Subscribe(s)
+	err := s.events.Subscribe(s)
 	assert.Nil(s.T(), err)
 
-	err = Events.Subscribe(s)
+	err = s.events.Subscribe(s)
 	assert.Nil(s.T(), err)
 
 	testDummy := &TestDummy{}
-	err = Events.Subscribe(testDummy)
+	err = s.events.Subscribe(testDummy)
 	assert.Nil(s.T(), err)
 
-	err = Events.Unsubscribe(s)
+	err = s.events.Unsubscribe(s)
 	assert.Nil(s.T(), err)
 
-	err = Events.Unsubscribe(s)
+	err = s.events.Unsubscribe(s)
 	assert.Nil(s.T(), err)
 
-	err = Events.Unsubscribe(testDummy)
+	err = s.events.Unsubscribe(testDummy)
 	assert.Nil(s.T(), err)
 }
 
 func (s *EventsTestSuite) Test_Publish_Core() {
-	err := Events.subscribe(api.EventHandlerLevelCore, s)
+	err := s.events.subscribe(api.EventHandlerLevelCore, s)
 	assert.Nil(s.T(), err)
 
-	Events.Publish(api.EventPayload{})
+	s.events.Publish(api.EventPayload{})
 
 	assert.True(s.T(), s.isHandlerInvoked())
 
-	err = Events.Unsubscribe(s)
+	err = s.events.Unsubscribe(s)
 	assert.Nil(s.T(), err)
 }
 
 func (s *EventsTestSuite) Test_Publish_Application() {
-	err := Events.Subscribe(s)
+	err := s.events.Subscribe(s)
 	assert.Nil(s.T(), err)
 
-	Events.Publish(api.EventPayload{})
+	s.events.Publish(api.EventPayload{})
 
 	time.Sleep(time.Millisecond * 200)
 	assert.True(s.T(), s.isHandlerInvoked())
 
-	err = Events.Unsubscribe(s)
+	err = s.events.Unsubscribe(s)
 	assert.Nil(s.T(), err)
 }

--- a/spine/feature_local.go
+++ b/spine/feature_local.go
@@ -805,7 +805,7 @@ func (r *FeatureLocal) processReply(message *api.Message) *model.ErrorType {
 		CmdClassifier: util.Ptr(model.CmdClassifierTypeReply),
 		Data:          cmdData.Value,
 	}
-	Events.Publish(payload)
+	r.Device().Events().Publish(payload)
 
 	// we don't need to populate this message if there is no MsgCounterReference
 	if message.RequestHeader == nil || message.RequestHeader.MsgCounterReference == nil {
@@ -843,7 +843,7 @@ func (r *FeatureLocal) processNotify(function model.FunctionType, data any, filt
 		CmdClassifier: util.Ptr(model.CmdClassifierTypeNotify),
 		Data:          data,
 	}
-	Events.Publish(payload)
+	r.Device().Events().Publish(payload)
 
 	return nil
 }
@@ -889,7 +889,7 @@ func (r *FeatureLocal) executeWrite(msg *api.Message) *model.ErrorType {
 		CmdClassifier: util.Ptr(model.CmdClassifierTypeWrite),
 		Data:          cmdData.Value,
 	}
-	Events.Publish(payload)
+	r.Device().Events().Publish(payload)
 
 	return nil
 }

--- a/spine/nodemanagement_detaileddiscovery.go
+++ b/spine/nodemanagement_detaileddiscovery.go
@@ -73,7 +73,7 @@ func (r *NodeManagement) processReplyDetailedDiscoveryData(message *api.Message,
 		Device:     remoteDevice,
 		Data:       data,
 	}
-	Events.Publish(payload)
+	r.Device().Events().Publish(payload)
 
 	// publish event for each added remote entity
 	for _, entity := range entities {
@@ -85,7 +85,7 @@ func (r *NodeManagement) processReplyDetailedDiscoveryData(message *api.Message,
 			Entity:     entity,
 			Data:       data,
 		}
-		Events.Publish(payload)
+		r.Device().Events().Publish(payload)
 	}
 
 	return nil
@@ -241,7 +241,7 @@ func (r *NodeManagement) processNotifyDetailedDiscoveryData(message *api.Message
 					Entity:     entity,
 					Data:       data,
 				}
-				Events.Publish(payload)
+				r.Device().Events().Publish(payload)
 			}
 		}
 
@@ -283,7 +283,7 @@ func (r *NodeManagement) processNotifyDetailedDiscoveryData(message *api.Message
 					Entity:     removedEntity,
 					Data:       data,
 				}
-				Events.Publish(payload)
+				r.Device().Events().Publish(payload)
 
 				// remove all subscriptions for this entity
 				subscriptionMgr := r.Device().SubscriptionManager()

--- a/spine/nodemanagement_usecase.go
+++ b/spine/nodemanagement_usecase.go
@@ -41,7 +41,7 @@ func (r *NodeManagement) processReplyUseCaseData(message *api.Message, data *mod
 		CmdClassifier: util.Ptr(message.CmdClassifier),
 		Data:          data,
 	}
-	Events.Publish(payload)
+	r.Device().Events().Publish(payload)
 
 	return nil
 }

--- a/spine/subscription_manager.go
+++ b/spine/subscription_manager.go
@@ -67,7 +67,7 @@ func (c *SubscriptionManager) AddSubscription(remoteDevice api.DeviceRemoteInter
 		Feature:      remoteFeature,
 		LocalFeature: localFeature,
 	}
-	Events.Publish(payload)
+	c.localDevice.Events().Publish(payload)
 
 	return nil
 }
@@ -138,7 +138,7 @@ func (c *SubscriptionManager) RemoveSubscription(remoteDevice api.DeviceRemoteIn
 				Feature:      remoteFeature,
 				LocalFeature: localFeature,
 			}
-			Events.Publish(payload)
+			c.localDevice.Events().Publish(payload)
 		}
 	}
 


### PR DESCRIPTION
BREAKING CHANGE: The global `spine.Events` has been removed. Each DeviceLocal now creates and owns its own events manager, accessible via `device.Events()`.

This change enables automatic test isolation when multiple DeviceLocal instances exist in the same process (e.g., simulating both a controlbox and HEMS in unit tests).

Migration required in consuming code:
  - spine.Events.Subscribe(h)  →  localEntity.Device().Events().Subscribe(h)
  - spine.Events.Publish(p)    →  device.Events().Publish(p)

Changes:
- Add EventsManagerInterface to api/events.go
- Add Events() method to DeviceLocalInterface
- Remove global Events variable from spine/events.go
- DeviceLocal creates own events instance in constructor
- All internal publishers now use device.Events()