### PR TITLE
fix(spine): nil-check remoteFeature in SubscribeToRemote/BindToRemote (minimal patch for #87)

### DIFF
--- a/spine/feature_local.go
+++ b/spine/feature_local.go
@@ -457,6 +457,9 @@ func (r *FeatureLocal) SubscribeToRemote(remoteAddress *model.FeatureAddressType
 	}
 
 	remoteFeature := remoteDevice.FeatureByAddress(remoteAddress)
+	if remoteFeature == nil {
+		return nil, model.NewErrorTypeFromString("feature not found")
+	}
 	remoteFeatureType := remoteFeature.Type()
 	if remoteFeature.Role() == model.RoleTypeClient {
 		return nil, model.NewErrorTypeFromString(fmt.Sprintf("remote feature '%s' is not a server", remoteFeature.String()))
@@ -580,6 +583,9 @@ func (r *FeatureLocal) BindToRemote(remoteAddress *model.FeatureAddressType) (*m
 	}
 
 	remoteFeature := remoteDevice.FeatureByAddress(remoteAddress)
+	if remoteFeature == nil {
+		return nil, model.NewErrorTypeFromString("feature not found")
+	}
 	remoteFeatureType := remoteFeature.Type()
 	if remoteFeature.Role() == model.RoleTypeClient {
 		return nil, model.NewErrorTypeFromString(fmt.Sprintf("remote feature '%s' is not a server", remoteFeature.String()))

--- a/spine/feature_local_test.go
+++ b/spine/feature_local_test.go
@@ -1240,3 +1240,48 @@ func (s *LocalFeatureTestSuite) Test_Operations_NoPartialReadSupport() {
 	assert.True(s.T(), exists)
 	assert.False(s.T(), operation.ReadPartial())
 }
+
+// TestSubscribeToRemote_NilFeature verifies that SubscribeToRemote
+// returns a proper error when FeatureByAddress() returns nil for the
+// requested address, instead of panicking on a nil-pointer dereference.
+//
+// This protects callers (notably eebus-go's eg/lpc.connected() event
+// handler) from crashing in the Publish() goroutine when a remote
+// device advertises a feature address that is not yet materialized in
+// the local entity model.
+func (s *LocalFeatureTestSuite) TestSubscribeToRemote_NilFeature() {
+	s.localFeature.Device().AddRemoteDeviceForSki(s.remoteFeature.Device().Ski(), s.remoteFeature.Device())
+
+	// Build an address that targets the remote device but a non-existent
+	// (entity, feature) tuple. FeatureByAddress() will return nil for it.
+	bogusFeatureAddr := &model.FeatureAddressType{
+		Device:  s.remoteFeature.Address().Device,
+		Entity:  []model.AddressEntityType{99999},
+		Feature: util.Ptr(model.AddressFeatureType(99999)),
+	}
+
+	// Must not panic; must return a proper ErrorType.
+	assert.NotPanics(s.T(), func() {
+		msgCounter, err := s.localFeature.SubscribeToRemote(bogusFeatureAddr)
+		assert.Nil(s.T(), msgCounter)
+		assert.NotNil(s.T(), err)
+	})
+}
+
+// TestBindToRemote_NilFeature mirrors TestSubscribeToRemote_NilFeature
+// for the BindToRemote() code path.
+func (s *LocalFeatureTestSuite) TestBindToRemote_NilFeature() {
+	s.localFeature.Device().AddRemoteDeviceForSki(s.remoteFeature.Device().Ski(), s.remoteFeature.Device())
+
+	bogusFeatureAddr := &model.FeatureAddressType{
+		Device:  s.remoteFeature.Address().Device,
+		Entity:  []model.AddressEntityType{99999},
+		Feature: util.Ptr(model.AddressFeatureType(99999)),
+	}
+
+	assert.NotPanics(s.T(), func() {
+		msgCounter, err := s.localFeature.BindToRemote(bogusFeatureAddr)
+		assert.Nil(s.T(), msgCounter)
+		assert.NotNil(s.T(), err)
+	})
+}


### PR DESCRIPTION
Fixes #87. Minimal-scope alternative to #88.

## Problem

`FeatureLocal.SubscribeToRemote` and `BindToRemote` dereference `remoteDevice.FeatureByAddress()` without a nil-check. When a remote device advertises a feature address that the local entity model has not yet materialized, `FeatureByAddress` returns `nil` and the subsequent `.Type()` / `.Role()` call panics inside the `spine.(*events).Publish` goroutine, killing the process.

Reproduced reliably in `eebus-go` EG-LPC use case startup: `lpc.(*LPC).connected()` runs `Subscribe()` while the remote's `LoadControl` feature has not yet been published.

```
panic: runtime error: invalid memory address or nil pointer dereference
spine.(*FeatureLocal).SubscribeToRemote
    spine/feature_local.go:451
eebus-go/features/client.(*Feature).Subscribe
eebus-go/usecases/eg/lpc.(*LPC).connected
    usecases/eg/lpc/events.go:76
created by spine.(*events).Publish
```

## Fix

Mirror the existing nil-check pattern used immediately above (for `remoteAddress.Device` and `remoteDevice`): return a proper `*model.ErrorType("feature not found")` that the calling code already handles as a debug-level non-fatal event.

## Scope

- 6 production lines in `spine/feature_local.go`
- 2 new test cases (`TestSubscribeToRemote_NilFeature`, `TestBindToRemote_NilFeature`)
- No behavioural change for the non-nil path

## Relation to #88

#88 from @SAY-5 also addresses #87 with the same conceptual approach (nil-check + early error return), but additionally contains a wider refactor (199 changed files, +23573/-4189 LoC). The maintainer may prefer either path:

- **This PR**: minimal-surface fix, easy to review, focused on the immediate panic
- **#88**: larger refactor that includes this fix as part of broader changes

Happy to defer to whichever direction you'd like to land — the issue itself is what matters.

## Test

`go test ./spine/...` clean. Two new tests verify the error-returning path is taken when `FeatureByAddress` returns nil.

## Provenance

Patch has been running in our internal `synervatt/spine-go` fork since 2026-04-21 without regressions in the `eebus-go` EG-LPC integration path.

— Thomas, Terabyte GmbH
