### PR TITLE
fix: tolerate unknown featureType in discovery reply (#96)

### DIFF
--- a/spine/function_data_factory.go
+++ b/spine/function_data_factory.go
@@ -302,7 +302,9 @@ func CreateFunctionData[F any](featureType model.FeatureTypeType) []F {
 	}
 
 	if len(result) == 0 {
-		panic(fmt.Errorf("unknown featureType '%s'", featureType))
+		// Unknown featureType from a future SPINE version — store with no function data.
+		// Per forward-compatibility rules the DUT MUST NOT reject or crash (TC_SPINE_RTS_002).
+		return result // empty slice; caller must tolerate nil/empty function data
 	}
 
 	return result

--- a/spine/rts_forward_compat_test.go
+++ b/spine/rts_forward_compat_test.go
@@ -1,0 +1,86 @@
+package spine
+
+// TC_SPINE_RTS_001 / TC_SPINE_RTS_002 — forward compatibility: tolerate arbitrary/unknown client
+// Feature types in nodeManagementDetailedDiscoveryData replies.
+//
+// Spec scenario: test tool (EG) sends a discovery reply where its client Feature is announced
+// with an unexpected featureType. DUT (CS/server) MUST process the reply without error and
+// proceed with commissioning (binding, subscription).
+//
+// PAR_replyDiscoveryKnownArbitraryType  → featureType = "DeviceClassification", role = "client"
+// PAR_replyDiscoveryUnknownFutureType   → featureType = "CompletelyUnknownFeatureType", role = "client",
+//                                         specificationVersion = "1.999.999"
+
+import (
+	"testing"
+
+	"github.com/enbility/spine-go/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	rts001_discovery_reply_file = "./testdata/rts001_discovery_reply_arbitrary_type.json"
+	rts002_discovery_reply_file = "./testdata/rts002_discovery_reply_unknown_type.json"
+)
+
+func TestRTSSuite(t *testing.T) {
+	suite.Run(t, new(RTSSuite))
+}
+
+type RTSSuite struct {
+	suite.Suite
+	sut          *DeviceLocal
+	writeHandler *WriteMessageHandler
+	remoteDevice *DeviceRemote
+}
+
+func (s *RTSSuite) BeforeTest(_, _ string) {
+	s.sut = NewDeviceLocal("brand", "model", "serial", "code", "HEMS",
+		model.DeviceTypeTypeEnergyManagementSystem, model.NetworkManagementFeatureSetTypeSmart)
+	s.writeHandler = &WriteMessageHandler{}
+	_ = s.sut.SetupRemoteDevice("eg-ski", s.writeHandler)
+	s.remoteDevice = s.sut.RemoteDeviceForSki("eg-ski").(*DeviceRemote)
+}
+
+// TC_SPINE_RTS_001: Discovery reply with arbitrary KNOWN featureType on client Feature.
+// DUT MUST process without error — entity and features stored, DeviceDiagnosis server
+// still reachable for subscription.
+func (s *RTSSuite) TestRTS001_DiscoveryReply_ArbitraryKnownClientType() {
+	_, err := s.remoteDevice.HandleSpineMesssage(loadFileData(s.T(), rts001_discovery_reply_file))
+
+	// Must not error — DUT silently tolerates unexpected client featureType
+	assert.Nil(s.T(), err, "TC_SPINE_RTS_001: HandleSpineMesssage must not error for arbitrary known featureType")
+
+	// Remote entity must be present
+	remoteEntity := s.remoteDevice.Entity([]model.AddressEntityType{1})
+	assert.NotNil(s.T(), remoteEntity, "TC_SPINE_RTS_001: remote entity must be discoverable after reply")
+
+	// DeviceDiagnosis server feature (used by CS to subscribe for heartbeats) must be reachable
+	ddServer := s.remoteDevice.FeatureByEntityTypeAndRole(
+		remoteEntity, model.FeatureTypeTypeDeviceDiagnosis, model.RoleTypeServer)
+	assert.NotNil(s.T(), ddServer,
+		"TC_SPINE_RTS_001: DeviceDiagnosis server feature must be found — CS needs it to subscribe for heartbeats")
+}
+
+// TC_SPINE_RTS_002: Discovery reply with completely UNKNOWN future featureType on client Feature,
+// plus higher specificationVersion ("1.999.999").
+// Current behaviour: spine-go PANICS in NewFeatureRemote → function_data_factory.go:305
+// Expected behaviour: unknown featureType silently ignored/stored, commissioning proceeds.
+func (s *RTSSuite) TestRTS002_DiscoveryReply_UnknownFutureClientType() {
+	// This test currently panics — captures the spec violation
+	assert.NotPanics(s.T(), func() {
+		_, _ = s.remoteDevice.HandleSpineMesssage(loadFileData(s.T(), rts002_discovery_reply_file))
+	}, "TC_SPINE_RTS_002: HandleSpineMesssage must not panic for unknown future featureType")
+
+	// Remote entity must be present after processing
+	remoteEntity := s.remoteDevice.Entity([]model.AddressEntityType{1})
+	assert.NotNil(s.T(), remoteEntity,
+		"TC_SPINE_RTS_002: remote entity must be discoverable after reply with unknown featureType")
+
+	// Known features (DeviceDiagnosis server) must still be reachable
+	ddServer := s.remoteDevice.FeatureByEntityTypeAndRole(
+		remoteEntity, model.FeatureTypeTypeDeviceDiagnosis, model.RoleTypeServer)
+	assert.NotNil(s.T(), ddServer,
+		"TC_SPINE_RTS_002: DeviceDiagnosis server feature must survive alongside unknown featureType")
+}

--- a/spine/testdata/rts001_discovery_reply_arbitrary_type.json
+++ b/spine/testdata/rts001_discovery_reply_arbitrary_type.json
@@ -1,0 +1,118 @@
+{
+    "datagram": {
+        "header": {
+            "specificationVersion": "1.3.0",
+            "addressSource": {
+                "device": "EnergyGuard",
+                "entity": [0],
+                "feature": 0
+            },
+            "addressDestination": {
+                "device": "HEMS",
+                "entity": [0],
+                "feature": 0
+            },
+            "msgCounter": 2,
+            "msgCounterReference": 1,
+            "cmdClassifier": "reply"
+        },
+        "payload": {
+            "cmd": [
+                {
+                    "nodeManagementDetailedDiscoveryData": {
+                        "specificationVersionList": {
+                            "specificationVersion": ["1.3.0"]
+                        },
+                        "deviceInformation": {
+                            "description": {
+                                "deviceAddress": {
+                                    "device": "EnergyGuard"
+                                },
+                                "deviceType": "EnergyManagementSystem",
+                                "networkFeatureSet": "smart"
+                            }
+                        },
+                        "entityInformation": [
+                            {
+                                "description": {
+                                    "entityAddress": {
+                                        "device": "EnergyGuard",
+                                        "entity": [0]
+                                    },
+                                    "entityType": "DeviceInformation"
+                                }
+                            },
+                            {
+                                "description": {
+                                    "entityAddress": {
+                                        "device": "EnergyGuard",
+                                        "entity": [1]
+                                    },
+                                    "entityType": "EnergyManagementSystem"
+                                }
+                            }
+                        ],
+                        "featureInformation": [
+                            {
+                                "description": {
+                                    "featureAddress": {
+                                        "device": "EnergyGuard",
+                                        "entity": [0],
+                                        "feature": 0
+                                    },
+                                    "featureType": "NodeManagement",
+                                    "role": "special",
+                                    "supportedFunction": [
+                                        {"function": "nodeManagementDetailedDiscoveryData", "possibleOperations": {"read": {}}},
+                                        {"function": "nodeManagementSubscriptionRequestCall", "possibleOperations": {}},
+                                        {"function": "nodeManagementSubscriptionDeleteCall", "possibleOperations": {}},
+                                        {"function": "nodeManagementSubscriptionData", "possibleOperations": {"read": {}}},
+                                        {"function": "nodeManagementBindingRequestCall", "possibleOperations": {}},
+                                        {"function": "nodeManagementBindingDeleteCall", "possibleOperations": {}},
+                                        {"function": "nodeManagementBindingData", "possibleOperations": {"read": {}}}
+                                    ]
+                                }
+                            },
+                            {
+                                "description": {
+                                    "featureAddress": {
+                                        "device": "EnergyGuard",
+                                        "entity": [1],
+                                        "feature": 1
+                                    },
+                                    "featureType": "DeviceClassification",
+                                    "role": "client"
+                                }
+                            },
+                            {
+                                "description": {
+                                    "featureAddress": {
+                                        "device": "EnergyGuard",
+                                        "entity": [1],
+                                        "feature": 2
+                                    },
+                                    "featureType": "DeviceDiagnosis",
+                                    "role": "server",
+                                    "supportedFunction": [
+                                        {"function": "deviceDiagnosisHeartbeatData", "possibleOperations": {"notify": {}}}
+                                    ]
+                                }
+                            },
+                            {
+                                "description": {
+                                    "featureAddress": {
+                                        "device": "EnergyGuard",
+                                        "entity": [1],
+                                        "feature": 3
+                                    },
+                                    "featureType": "DeviceDiagnosis",
+                                    "role": "client"
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/spine/testdata/rts002_discovery_reply_unknown_type.json
+++ b/spine/testdata/rts002_discovery_reply_unknown_type.json
@@ -1,0 +1,118 @@
+{
+    "datagram": {
+        "header": {
+            "specificationVersion": "1.999.999",
+            "addressSource": {
+                "device": "EnergyGuard",
+                "entity": [0],
+                "feature": 0
+            },
+            "addressDestination": {
+                "device": "HEMS",
+                "entity": [0],
+                "feature": 0
+            },
+            "msgCounter": 2,
+            "msgCounterReference": 1,
+            "cmdClassifier": "reply"
+        },
+        "payload": {
+            "cmd": [
+                {
+                    "nodeManagementDetailedDiscoveryData": {
+                        "specificationVersionList": {
+                            "specificationVersion": ["1.999.999"]
+                        },
+                        "deviceInformation": {
+                            "description": {
+                                "deviceAddress": {
+                                    "device": "EnergyGuard"
+                                },
+                                "deviceType": "EnergyManagementSystem",
+                                "networkFeatureSet": "smart"
+                            }
+                        },
+                        "entityInformation": [
+                            {
+                                "description": {
+                                    "entityAddress": {
+                                        "device": "EnergyGuard",
+                                        "entity": [0]
+                                    },
+                                    "entityType": "DeviceInformation"
+                                }
+                            },
+                            {
+                                "description": {
+                                    "entityAddress": {
+                                        "device": "EnergyGuard",
+                                        "entity": [1]
+                                    },
+                                    "entityType": "EnergyManagementSystem"
+                                }
+                            }
+                        ],
+                        "featureInformation": [
+                            {
+                                "description": {
+                                    "featureAddress": {
+                                        "device": "EnergyGuard",
+                                        "entity": [0],
+                                        "feature": 0
+                                    },
+                                    "featureType": "NodeManagement",
+                                    "role": "special",
+                                    "supportedFunction": [
+                                        {"function": "nodeManagementDetailedDiscoveryData", "possibleOperations": {"read": {}}},
+                                        {"function": "nodeManagementSubscriptionRequestCall", "possibleOperations": {}},
+                                        {"function": "nodeManagementSubscriptionDeleteCall", "possibleOperations": {}},
+                                        {"function": "nodeManagementSubscriptionData", "possibleOperations": {"read": {}}},
+                                        {"function": "nodeManagementBindingRequestCall", "possibleOperations": {}},
+                                        {"function": "nodeManagementBindingDeleteCall", "possibleOperations": {}},
+                                        {"function": "nodeManagementBindingData", "possibleOperations": {"read": {}}}
+                                    ]
+                                }
+                            },
+                            {
+                                "description": {
+                                    "featureAddress": {
+                                        "device": "EnergyGuard",
+                                        "entity": [1],
+                                        "feature": 1
+                                    },
+                                    "featureType": "CompletelyUnknownFeatureType",
+                                    "role": "client"
+                                }
+                            },
+                            {
+                                "description": {
+                                    "featureAddress": {
+                                        "device": "EnergyGuard",
+                                        "entity": [1],
+                                        "feature": 2
+                                    },
+                                    "featureType": "DeviceDiagnosis",
+                                    "role": "server",
+                                    "supportedFunction": [
+                                        {"function": "deviceDiagnosisHeartbeatData", "possibleOperations": {"notify": {}}}
+                                    ]
+                                }
+                            },
+                            {
+                                "description": {
+                                    "featureAddress": {
+                                        "device": "EnergyGuard",
+                                        "entity": [1],
+                                        "feature": 3
+                                    },
+                                    "featureType": "DeviceDiagnosis",
+                                    "role": "client"
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes panic in `HandleSpineMesssage` when a discovery reply contains an
unknown/future featureType (TC_SPINE_RTS_002). Instead of panicking,
`function_data_factory.go` now returns an empty function-data set for
unrecognized types, and downstream code (`feature_remote.go`,
`device_remote.go`) handles that gracefully.

TC_SPINE_RTS_001 (arbitrary known featureType) already passed at the
protocol layer — no fix needed there.

Closes #96

## Testing

- Added `spine/rts_forward_compat_test.go` covering both RTS_001 and RTS_002
- `go test -v ./spine -run TestRTSSuite` passes
- Tested with a real device, found to be working