### PR TITLE
test: annotate tests with covered SPINE test-spec cases

### DIFF
--- a/spine/device_local_test.go
+++ b/spine/device_local_test.go
@@ -223,6 +223,7 @@ func (d *DeviceLocalTestSuite) Test_ProcessCmd_NotifyError() {
 	assert.NotNil(d.T(), err)
 }
 
+// TC_SPINE_FC_001: reject commands whose destination does not resolve to a valid local entity/feature (e.g. not Entity 0/Feature 0 NodeManagement).
 func (d *DeviceLocalTestSuite) Test_ProcessCmd_Errors() {
 	sut := NewDeviceLocal("brand", "model", "serial", "code", "address", model.DeviceTypeTypeEnergyManagementSystem, model.NetworkManagementFeatureSetTypeSmart)
 	localEntity := NewEntityLocal(sut, model.EntityTypeTypeCEM, NewAddressEntityType([]uint{1}), time.Second*4)
@@ -422,6 +423,7 @@ func (d *DeviceLocalTestSuite) Test_ProcessCmd() {
 	err = sut.ProcessCmd(datagram, remote)
 	assert.NotNil(d.T(), err)
 
+	// TC_SPINE_BIND_002: even with write enabled on the function, a write is rejected while no binding exists (errorNumber 9, BindingIsNecessary).
 	f3.AddFunctionType(model.FunctionTypeElectricalConnectionParameterDescriptionListData, true, true)
 	err = sut.ProcessCmd(datagram, remote)
 	assert.NotNil(d.T(), err)

--- a/spine/feature_local_test.go
+++ b/spine/feature_local_test.go
@@ -546,6 +546,7 @@ func (s *LocalFeatureTestSuite) Test_HandleMessage() {
 	assert.NotNil(s.T(), err)
 }
 
+// TC_SPINE_DATA_006, TC_SPINE_DATA_008: do not respond to an incoming resultData/result datagram, even on error.
 func (s *LocalFeatureTestSuite) Test_Result() {
 	msg := &api.Message{
 		FeatureRemote: s.remoteServerFeature,
@@ -600,6 +601,7 @@ func (s *LocalFeatureTestSuite) Test_Read() {
 	assert.NotNil(s.T(), err)
 }
 
+// TC_SPINE_COMP_004: an incoming reply is accepted without emitting an application error (errorNumber > 0) response.
 func (s *LocalFeatureTestSuite) Test_Reply() {
 	msg := &api.Message{
 		FeatureRemote: s.remoteServerFeature,

--- a/spine/feature_local_unknown_function_test.go
+++ b/spine/feature_local_unknown_function_test.go
@@ -12,6 +12,7 @@ import (
 // TestFeatureLocal_UnknownFunction_ErrorCode6 verifies that spine-go returns
 // error code 6 (CommandNotSupported) for unknown functions as per SPINE specification.
 // This test confirms the fix from returning error code 1 (GeneralError) to error code 6.
+// TC_SPINE_COMP_001: reject a request for an unknown/unsupported Function with errorNumber > 0 (CommandNotSupported).
 func TestFeatureLocal_UnknownFunction_ErrorCode6(t *testing.T) {
 	// Setup
 	_, localEntity := createLocalDeviceAndEntity(1)

--- a/spine/msgcounter_integration_test.go
+++ b/spine/msgcounter_integration_test.go
@@ -129,6 +129,7 @@ func (s *MsgCounterIntegrationSuite) Test_MultiDevice_Independent_Counters() {
 
 // Test device reset scenario - msgCounter drops from high to low value
 // This test demonstrates the missing implementation of SPINE spec requirement
+// TC_SPINE_DATA_003: process incoming datagrams as usual even if the msgCounter is lower than the last received (reset/overflow).
 func (s *MsgCounterIntegrationSuite) Test_DeviceReset_Detection_Gap() {
 	// Device sends messages with increasing counters
 	normalCounters := []model.MsgCounterType{100, 101, 102}

--- a/spine/msgcounter_property_test.go
+++ b/spine/msgcounter_property_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 // Property 1: msgCounter values are always ascending (except at overflow)
+// TC_SPINE_DATA_001: outgoing msgCounter values are assigned in strictly ascending order.
 func TestProperty_MsgCounter_AlwaysAscending(t *testing.T) {
 	config := &quick.Config{
 		MaxCount: 1000,

--- a/spine/nodemanagement_detaileddiscovery_test.go
+++ b/spine/nodemanagement_detaileddiscovery_test.go
@@ -44,6 +44,7 @@ func (s *NodeManagementSuite) BeforeTest(suiteName, testName string) {
 	s.remoteDevice = s.sut.RemoteDeviceForSki(s.remoteSki)
 }
 
+// TC_SPINE_DDISC_001: a client-capable DUT actively sends an initial nodeManagementDetailedDiscoveryData read on a new connection.
 func (s *NodeManagementSuite) TestDetailedDiscovery_SendRead() {
 	// Act (see BeforeTest)
 
@@ -52,6 +53,7 @@ func (s *NodeManagementSuite) TestDetailedDiscovery_SendRead() {
 	checkSentData(s.T(), sendBytes, nm_detaileddiscoverydata_send_read_file_prefix)
 }
 
+// TC_SPINE_DATA_004: a reply carries msgCounterReference matching the originating request's msgCounter (fetched here via MessageWithReference).
 func (s *NodeManagementSuite) TestDetailedDiscovery_SendReply() {
 	// Act
 	msgCounter, _ := s.remoteDevice.HandleSpineMesssage(loadFileData(s.T(), nm_detaileddiscoverydata_recv_read_file_path))
@@ -61,6 +63,7 @@ func (s *NodeManagementSuite) TestDetailedDiscovery_SendReply() {
 	checkSentData(s.T(), sendBytes, nm_detaileddiscoverydata_send_reply_file_prefix)
 }
 
+// TC_SPINE_ENTITY_001: dynamically discover remote server entities/features from a detailed-discovery reply regardless of their addresses.
 func (s *NodeManagementSuite) TestDetailedDiscovery_RecvReply() {
 	// Act
 	_, _ = s.remoteDevice.HandleSpineMesssage(loadFileData(s.T(), wallbox_detaileddiscoverydata_recv_reply_file_path))
@@ -118,6 +121,7 @@ func (s *NodeManagementSuite) TestDetailedDiscovery_RecvReply() {
 	assert.Equal(s.T(), 0, len(evseec.Operations()))
 }
 
+// TC_SPINE_DATA_005: acknowledge a received notify datagram (ackRequest set) with a resultData message (errorNumber = 0).
 func (s *NodeManagementSuite) TestDetailedDiscovery_RecvNotifyAdded() {
 	_, _ = s.remoteDevice.HandleSpineMesssage(loadFileData(s.T(), wallbox_detaileddiscoverydata_recv_reply_file_path))
 

--- a/spine/nodemanagement_subscription_test.go
+++ b/spine/nodemanagement_subscription_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+// TC_SPINE_SUBS_001: accept a subscription request to the primary NodeManagement feature.
 func TestNodemanagement_SubscriptionCalls(t *testing.T) {
 	const subscriptionEntityId uint = 1
 	const featureType = model.FeatureTypeTypeDeviceClassification

--- a/spine/subscription_manager_test.go
+++ b/spine/subscription_manager_test.go
@@ -43,6 +43,7 @@ func (s *SubscriptionManagerSuite) BeforeTest(suiteName, testName string) {
 	s.sut = NewSubscriptionManager(s.localDevice)
 }
 
+// TC_SPINE_SUBS_002: deleting a subscription is idempotent - removing an already-absent subscription still returns success.
 func (s *SubscriptionManagerSuite) Test_Subscriptions() {
 	entity := NewEntityLocal(s.localDevice, model.EntityTypeTypeCEM, []model.AddressEntityType{1}, time.Second*4)
 	s.localDevice.AddEntity(entity)

--- a/spine/util_test.go
+++ b/spine/util_test.go
@@ -62,6 +62,7 @@ func (s *UtilsSuite) Test_isMatchingClientOrServerByDeviceAndEntity() {
 	assert.True(s.T(), result)
 }
 
+// TC_SPINE_RTS_001: tolerate/resolve client features of any known SPINE feature type via their address+role.
 func (s *UtilsSuite) Test_addressDetails() {
 	s.localDevice = NewDeviceLocal("brand", "model", "serial", "code", "address", model.DeviceTypeTypeEnergyManagementSystem, model.NetworkManagementFeatureSetTypeSmart)
 


### PR DESCRIPTION
Makes SPINE High-Level Test Specification (V1.0.0) coverage explicit: adds a one-line `// TC_SPINE_...` reference comment to each existing test that already exercises a conformant test-case requirement. **Comment-only** — no production code, test logic, or assertions changed; `./spine` stays green.

Contributes to #94 (SPINE TestSpecification compliance) by making the "already covered" cases traceable in-code.

## Annotated

| TC | Test |
|----|------|
| BIND_002 | `device_local_test.go` `Test_ProcessCmd` (unbound-write assertion) |
| COMP_001 | `feature_local_unknown_function_test.go` `TestFeatureLocal_UnknownFunction_ErrorCode6` |
| COMP_004 | `feature_local_test.go` `Test_Reply` |
| DATA_001 | `msgcounter_property_test.go` `TestProperty_MsgCounter_AlwaysAscending` |
| DATA_003 | `msgcounter_integration_test.go` `Test_DeviceReset_Detection_Gap` |
| DATA_004 | `nodemanagement_detaileddiscovery_test.go` `TestDetailedDiscovery_SendReply` |
| DATA_005 | `nodemanagement_detaileddiscovery_test.go` `TestDetailedDiscovery_RecvNotifyAdded` |
| DATA_006/008 | `feature_local_test.go` `Test_Result` |
| DDISC_001 | `nodemanagement_detaileddiscovery_test.go` `TestDetailedDiscovery_SendRead` |
| ENTITY_001 | `nodemanagement_detaileddiscovery_test.go` `TestDetailedDiscovery_RecvReply` |
| FC_001 | `device_local_test.go` `Test_ProcessCmd_Errors` |
| RTS_001 | `util_test.go` `Test_addressDetails` |
| SUBS_001 | `nodemanagement_subscription_test.go` `TestNodemanagement_SubscriptionCalls` |
| SUBS_002 | `subscription_manager_test.go` `Test_Subscriptions` |

## Not annotated (no test genuinely exercises the requirement yet)

COMP_002/003/005/006, RTC_001/002, RTS_002/004, DATA_002/007, DDISC_002, ENTITY_002 — mostly forward-compat "ignore unknown/extra elements/version" behavior that is inherent to `json.Unmarshal` but not deliberately exercised by any fixture, plus a couple of MAY requirements. Listed here so the gaps are visible rather than silently implied as covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
