### PR TITLE
fix(model): merge nested pointer-to-struct fields in updateFields

### DIFF
--- a/model/collection_operations.go
+++ b/model/collection_operations.go
@@ -102,16 +102,24 @@ func updateFields[T any](remoteWrite bool, source T, destination *T) {
 		return
 	}
 
-	writeCheckFields := fieldNamesWithEEBusTag(EEBusTagWriteCheck, source)
-
 	sV := reflect.ValueOf(source)
-	sT := reflect.TypeOf(source)
 	dV := reflect.ValueOf(destination).Elem()
 
+	updateFieldsValue(remoteWrite, sV, dV)
+}
+
+// updateFieldsValue does the actual field-by-field merge on plain reflect.Values.
+// Using reflect.Value instead of the generic T allows recursing into nested
+// pointer-to-struct fields (e.g. Value *ScaledNumberType) without running into
+// generic type-inference issues.
+func updateFieldsValue(remoteWrite bool, sV reflect.Value, dV reflect.Value) {
 	// if the fields don't match, don't do anything
-	if sV.Kind() != reflect.Struct || sV.NumField() != dV.NumField() {
+	if sV.Kind() != reflect.Struct || dV.Kind() != reflect.Struct || sV.NumField() != dV.NumField() {
 		return
 	}
+
+	writeCheckFields := fieldNamesWithEEBusTag(EEBusTagWriteCheck, sV.Interface())
+	sT := sV.Type()
 
 	for i := 0; i < sV.NumField(); i++ {
 		value := sV.Field(i)
@@ -128,6 +136,15 @@ func updateFields[T any](remoteWrite bool, source T, destination *T) {
 		if f.IsNil() ||
 			(remoteWrite && len(writeCheckFields) > 0 && slices.Contains(writeCheckFields, fieldName)) {
 			f.Set(value)
+			continue
+		}
+
+		// both sides carry a non-nil pointer-to-struct -> recurse and merge the
+		// inner fields (e.g. Scale inside ScaledNumberType) instead of leaving
+		// the destination's nested struct untouched.
+		if value.Kind() == reflect.Ptr && !value.IsNil() &&
+			f.Kind() == reflect.Ptr && f.Elem().Kind() == reflect.Struct {
+			updateFieldsValue(remoteWrite, value.Elem(), f.Elem())
 		}
 	}
 }

--- a/model/udpdate_rfe_scaled_number_test.go
+++ b/model/udpdate_rfe_scaled_number_test.go
@@ -1,0 +1,100 @@
+package model_test
+
+import (
+	"testing"
+
+	"github.com/enbility/spine-go/model"
+	"github.com/enbility/spine-go/util"
+	"github.com/stretchr/testify/assert"
+)
+
+// Test RFE partial write with ScaledNumberType:
+// When Scale is omitted from incoming data, it should be preserved from existing data
+func TestRFE_ScaledNumberType_OmitScale_PreservesExisting(t *testing.T) {
+	// Existing entry: value = 100 * 10^-1 = 10.0
+	existingData := []model.LoadControlLimitDataType{
+		{
+			LimitId: util.Ptr(model.LoadControlLimitIdType(1)),
+			IsLimitChangeable: util.Ptr(true),
+			Value: &model.ScaledNumberType{
+				Number: util.Ptr(model.NumberType(100)),
+				Scale:  util.Ptr(model.ScaleType(-1)), // Scale is -1
+			},
+		},
+	}
+
+	// Incoming partial write: new Number, but Scale omitted (nil)
+	// This simulates a partial write where scale is not provided
+	updateData := []model.LoadControlLimitDataType{
+		{
+			LimitId: util.Ptr(model.LoadControlLimitIdType(1)),
+			Value: &model.ScaledNumberType{
+				Number: util.Ptr(model.NumberType(250)), // New number
+				Scale:  nil, // Scale is omitted!
+			},
+		},
+	}
+
+	// Process without partial filter (direct merge)
+	result, success := model.UpdateList(false, existingData, updateData, nil, nil, nil)
+
+	assert.True(t, success, "update should succeed")
+	assert.NotNil(t, result)
+	assert.Len(t, result, 1)
+
+	// Check if Scale was preserved
+	resultEntry := result[0]
+	assert.NotNil(t, resultEntry.Value, "Value should not be nil")
+	assert.NotNil(t, resultEntry.Value.Number, "Number should not be nil")
+	assert.NotNil(t, resultEntry.Value.Scale, "Scale should be preserved from existing data")
+
+	if resultEntry.Value.Scale != nil {
+		t.Logf("Result: Number=%d, Scale=%d", *resultEntry.Value.Number, *resultEntry.Value.Scale)
+		if *resultEntry.Value.Scale == -1 {
+			t.Logf("✓ Scale preserved correctly as -1")
+		} else {
+			t.Errorf("✗ Scale was not preserved: got %d, expected -1", *resultEntry.Value.Scale)
+		}
+	}
+}
+
+// Test with partial filter (selector-based merge)
+func TestRFE_ScaledNumberType_PartialFilter_OmitScale(t *testing.T) {
+	existingData := []model.LoadControlLimitDataType{
+		{
+			LimitId: util.Ptr(model.LoadControlLimitIdType(1)),
+			IsLimitChangeable: util.Ptr(true),
+			Value: &model.ScaledNumberType{
+				Number: util.Ptr(model.NumberType(500)),
+				Scale:  util.Ptr(model.ScaleType(-2)), // Existing scale
+			},
+		},
+	}
+
+	updateData := []model.LoadControlLimitDataType{
+		{
+			Value: &model.ScaledNumberType{
+				Number: util.Ptr(model.NumberType(1000)),
+				Scale:  nil, // Omitted
+			},
+		},
+	}
+
+	// Create partial filter targeting the limit
+	filterPartial := model.NewFilterTypePartial()
+	filterPartial.LoadControlLimitListDataSelectors = &model.LoadControlLimitListDataSelectorsType{
+		LimitId: util.Ptr(model.LoadControlLimitIdType(1)),
+	}
+
+	result, success := model.UpdateList(false, existingData, updateData, filterPartial, nil, nil)
+
+	assert.True(t, success, "update should succeed")
+	assert.NotNil(t, result)
+	assert.Len(t, result, 1)
+
+	resultEntry := result[0]
+	if resultEntry.Value != nil && resultEntry.Value.Scale != nil {
+		t.Logf("Partial filter result: Number=%d, Scale=%d", 
+			*resultEntry.Value.Number, *resultEntry.Value.Scale)
+	}
+}


### PR DESCRIPTION
## Summary

`updateFields` in `model/collection_operations.go` only checked whether a
field's pointer itself was `nil` before deciding to copy a value from the
existing entry. For nested struct pointers (e.g. `LoadControlLimitDataType.Value
*ScaledNumberType`) this meant: if the incoming partial write set `Value` to a
non-nil pointer but left an inner field like `Scale` as `nil` (i.e. omitted),
that inner field was never merged and stayed `nil` instead of being preserved
from the existing entry.

Fix: split `updateFields[T]` into a thin generic wrapper and a new
non-generic `updateFieldsValue(remoteWrite bool, sV, dV reflect.Value)` that
does the actual field-by-field merge. When both source and destination carry
a non-nil pointer to a struct, `updateFieldsValue` now recurses into that
struct instead of stopping at the outer pointer. Recursion has to happen
through a non-generic helper because Go generics can't infer `T` again once
the nested value has been unwrapped via reflection.

Closes #97
Related to #94

## Testing

- Added `model/rfe_scaled_number_test.go`:
  - `TestRFE_ScaledNumberType_OmitScale_PreservesExisting` — direct merge without partial filter
  - `TestRFE_ScaledNumberType_PartialFilter_OmitScale` — merge via partial filter selector
- `go test -v ./model -run TestRFE_ScaledNumberType -count=1` passes
- `go test -v ./model -count=1` passes (existing `collection_operations_test.go` suite unaffected)