### PR TITLE
fix(model): accept scientific notation for NumberType (#89)

### DIFF
--- a/model/commondatatypes_additions.go
+++ b/model/commondatatypes_additions.go
@@ -349,11 +349,6 @@ func (a *AbsoluteOrRelativeTimeType) GetTimeDuration() (time.Duration, error) {
 func (n *NumberType) UnmarshalJSON(data []byte) error {
 	s := strings.TrimSpace(string(data))
 
-	// by convention, unmarshaling null is a no-op
-	if s == "null" {
-		return nil
-	}
-
 	if value, err := strconv.ParseInt(s, 10, 64); err == nil {
 		*n = NumberType(value)
 		return nil

--- a/model/commondatatypes_additions.go
+++ b/model/commondatatypes_additions.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"math/big"
 	"strconv"
 	"strings"
 	"time"
@@ -339,6 +340,34 @@ func (a *AbsoluteOrRelativeTimeType) GetDurationType() (*DurationType, error) {
 
 func (a *AbsoluteOrRelativeTimeType) GetTimeDuration() (time.Duration, error) {
 	return getTimeDurationFromString(string(*a))
+}
+
+// NumberType
+
+// UnmarshalJSON accepts numbers in scientific notation, which encoding/json
+// rejects for integer types, if they denote an exact integer (golang/go#5562)
+func (n *NumberType) UnmarshalJSON(data []byte) error {
+	s := strings.TrimSpace(string(data))
+
+	// by convention, unmarshaling null is a no-op
+	if s == "null" {
+		return nil
+	}
+
+	if value, err := strconv.ParseInt(s, 10, 64); err == nil {
+		*n = NumberType(value)
+		return nil
+	}
+
+	// big.Rat parses the decimal exponent notation exactly, unlike float64
+	value, ok := new(big.Rat).SetString(s)
+	if !ok || !value.IsInt() || !value.Num().IsInt64() {
+		return fmt.Errorf("json: cannot unmarshal %s into Go value of type model.NumberType", s)
+	}
+
+	*n = NumberType(value.Num().Int64())
+
+	return nil
 }
 
 // ScaledNumberType

--- a/model/commondatatypes_additions_test.go
+++ b/model/commondatatypes_additions_test.go
@@ -279,6 +279,67 @@ func TestAbsoluteOrRelativeTimeTypeRelative(t *testing.T) {
 	}
 }
 
+func TestScaledNumberTypeUnmarshal(t *testing.T) {
+	tc := []struct {
+		json   string
+		number int64
+		scale  int16
+	}{
+		{`{"number":42}`, 42, 0},
+		{`{"number":42,"scale":-2}`, 42, -2},
+		{`{"number":-9007199254740990}`, -9007199254740990, 0},
+		{`{"number":9007199254740990}`, 9007199254740990, 0},
+		// sender encodes the number in scientific notation (float-like)
+		{`{"number":9.00719925474099e+15}`, 9007199254740990, 0},
+		{`{"number":-9.00719925474099e+15}`, -9007199254740990, 0},
+		{`{"number":1E3}`, 1000, 0},
+		{`{"number":1.5e1}`, 15, 0},
+		{`{"number":42.0}`, 42, 0},
+	}
+
+	for _, tc := range tc {
+		var got ScaledNumberType
+		err := json.Unmarshal([]byte(tc.json), &got)
+		assert.NoError(t, err, "input: %s", tc.json)
+		if err != nil {
+			continue
+		}
+		assert.Equal(t, NumberType(tc.number), *got.Number, "input: %s", tc.json)
+		wantScale := ScaleType(tc.scale)
+		if tc.scale == 0 {
+			// scale is omitted when zero; accept both nil and explicit zero
+			if got.Scale != nil {
+				assert.Equal(t, wantScale, *got.Scale, "input: %s", tc.json)
+			}
+		} else {
+			assert.Equal(t, wantScale, *got.Scale, "input: %s", tc.json)
+		}
+	}
+}
+
+func TestScaledNumberTypeUnmarshalInvalid(t *testing.T) {
+	// only values decoding cleanly into an integer are accepted
+	tc := []string{
+		`{"number":1.5}`,
+		`{"number":1.55e1}`,
+		`{"number":9223372036854775808}`,
+		`{"number":1e19}`,
+		`{"number":"42"}`,
+		`{"number":true}`,
+	}
+
+	for _, in := range tc {
+		var got ScaledNumberType
+		assert.Error(t, json.Unmarshal([]byte(in), &got), "input: %s", in)
+	}
+}
+
+func TestScaledNumberTypeUnmarshalNull(t *testing.T) {
+	var got ScaledNumberType
+	assert.NoError(t, json.Unmarshal([]byte(`{"number":null}`), &got))
+	assert.Nil(t, got.Number)
+}
+
 func TestNewScaledNumberType(t *testing.T) {
 	tc := []struct {
 		in     float64

--- a/model/commondatatypes_additions_test.go
+++ b/model/commondatatypes_additions_test.go
@@ -334,12 +334,6 @@ func TestScaledNumberTypeUnmarshalInvalid(t *testing.T) {
 	}
 }
 
-func TestScaledNumberTypeUnmarshalNull(t *testing.T) {
-	var got ScaledNumberType
-	assert.NoError(t, json.Unmarshal([]byte(`{"number":null}`), &got))
-	assert.Nil(t, got.Number)
-}
-
 func TestNewScaledNumberType(t *testing.T) {
 	tc := []struct {
 		in     float64


### PR DESCRIPTION
## Summary

`encoding/json` refuses to unmarshal a JSON number written in scientific notation into an integer type, even when the value is a valid integer ([golang/go#5562](https://github.com/golang/go/issues/5562)). A device sending `{"scaledNumber":[{"number":9.00719925474099e+15},...]}` therefore makes the entire datagram fail to decode with `cannot unmarshal number ... into Go struct field ScaledNumberType...of type model.NumberType`.

`NumberType` now decodes the number itself. The condition is that the value can be decoded cleanly into an integer: it is accepted only if it denotes an exact integer that fits into `int64`, and rejected otherwise (`1.5`, `1.55e1`, `1e19`, out-of-range literals, non-numbers). `big.Rat` evaluates the decimal exponent form exactly, so no precision is lost above 2^53 the way a `float64` round-trip would.

`null` needs no special handling: every `NumberType` field is a `*NumberType`, and `encoding/json` sets the pointer to nil without calling `UnmarshalJSON`.

Closes #89

The reproduction test attached to the issue by @sthelen-enqs is included, extended with the rejection cases.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)